### PR TITLE
Switch to go get for glide

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN go install -v -a syscall
 RUN go install -v std
 
 # Install glide
-RUN curl https://glide.sh/get | sh
+RUN go get github.com/Masterminds/glide
 ENV GLIDE_HOME /home/user/.glide
 
 # Install ginkgo CLI tool for running tests


### PR DESCRIPTION
Currently https://glide.sh is down and is a silent failure for building the Docker image.  I switched it to using `go get github.com/Masterminds/glide`.  Another possibility is to switch the install to `RUN wget -q -O glide_get https://glide.sh/get && chmod u+x glide_get && ./glide_get && rm glide_get` which would result in a failure but will not work right now with the previously mentioned page not working.