### PR TITLE
Added docker for recipes that may build inside a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ MAINTAINER Tom Denham <tom@projectcalico.org>
 # Install wget for fetching glibc
 # Install make for building things
 # Install util-linux for column command (used for output formatting).
-RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux
+RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux docker
 
 # Disable ssh host key checking
 RUN echo 'Host *' >> /etc/ssh/ssh_config


### PR DESCRIPTION
Some builds require their dependencies to be built from a separate image.  To allow for this to happen within go-build we need docker for those cases.