### PR TITLE
Include yaml CLI tool in ppc64le go-build.

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -51,6 +51,9 @@ RUN go get github.com/pmezard/licenses
 # Install tool to merge coverage reports.
 RUN go get github.com/wadey/gocovmerge
 
+# Install CLI tool for working with yaml files
+RUN go get github.com/mikefarah/yaml
+
 # Install patched version of goveralls (upstream is bugged if not used from Travis).
 RUN go get -u -d github.com/fasaxc/goveralls && \
     cd /go/src/github.com/fasaxc/goveralls && \


### PR DESCRIPTION
Adding the yaml CLI tool in the ppc64le Dockerfile.  It was forgotten in the last round of patches.
Signed-off-by: David Wilder <wilder@us.ibm.com>