### PR TITLE
Add support for Arm64 server

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.8.1-alpine
+FROM arm64v8/golang:1.9.2-alpine3.6
 MAINTAINER Trevor Tao <trevor.tao@arm.com>
 
 # Install su-exec for use in the entrypoint.sh (so processes run as the right user)
@@ -10,15 +10,8 @@ MAINTAINER Trevor Tao <trevor.tao@arm.com>
 # Install wget for fetching glibc
 # Install make for building things
 # Install util-linux for column command (used for output formatting).
-RUN apk add --no-cache su-exec \
-  bash \
-  curl \
-  git \
-  make \
-  mercurial \
-  openssh \
-  util-linux \
-  wget
+RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux docker tini
+RUN apk upgrade --no-cache
 
 # Disable ssh host key checking
 RUN echo 'Host *' >> /etc/ssh/ssh_config \
@@ -29,15 +22,11 @@ RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/
   && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk \
   && apk add glibc-2.23-r3.apk
 
-# Disable cgo so that binaries we build will be fully static
+# Disable cgo so that binaries we build will be fully static.
 ENV CGO_ENABLED=0
 
-# Apply patches to Go runtime and recompile
-# See https://github.com/golang/go/issues/5838 for defails of vfork patch
-
-# Recompile the standard library with cgo disabled.
-# This prevents the standard library from being marked stale,
-# causing full rebuilds every time.
+# Recompile the standard library with cgo disabled.  This prevents the standard library from being
+# marked stale, causing full rebuilds every time.
 RUN go install -v std
 
 # Install glide
@@ -47,17 +36,23 @@ ENV GLIDE_HOME /home/user/.glide
 # Install ginkgo CLI tool for running tests
 RUN go get github.com/onsi/ginkgo/ginkgo
 
-# Install linting tools
-RUN go get -u gopkg.in/alecthomas/gometalinter.v1 \
-  && ln -s $(which gometalinter.v1) /usr/local/bin/gometalinter \
-  && gometalinter --install
+# Install linting tools.  We pin gometalinter to a working master revision to pick up
+# a go v1.9 compatibility patch that hasn't been released.
+RUN go get -u -d github.com/alecthomas/gometalinter && \
+    cd /go/src/github.com/alecthomas/gometalinter && \
+    git checkout cc4415ed09f7073d595ee504cad4d98b71a3038e && \
+    go install github.com/alecthomas/gometalinter
+RUN ln -s `which gometalinter` /usr/local/bin/gometalinter
+RUN gometalinter --install
 
-# Install license checking tool
+# Install license checking tool.
 RUN go get github.com/pmezard/licenses
 
-# Install tool to merge coverage reports
+# Install tool to merge coverage reports.
 RUN go get github.com/wadey/gocovmerge
 
+# Install CLI tool for working with yaml files
+RUN go get github.com/mikefarah/yaml
 
 # Install patched version of goveralls (upstream is bugged if not used from Travis).
 RUN go get -u -d github.com/fasaxc/goveralls && \
@@ -75,5 +70,4 @@ RUN go get -u -d github.com/fasaxc/goveralls && \
 RUN chmod -R 777 $GOPATH
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,5 +1,5 @@
 FROM arm64v8/golang:1.8.1-alpine
-MAINTAINER Tom Denham <tom@projectcalico.org>
+MAINTAINER Trevor Tao <trevor.tao@arm.com>
 
 # Install su-exec for use in the entrypoint.sh (so processes run as the right user)
 # Install bash for the entry script (and because it's generally useful)

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,79 @@
+FROM arm64v8/golang:1.8.1-alpine
+MAINTAINER Tom Denham <tom@projectcalico.org>
+
+# Install su-exec for use in the entrypoint.sh (so processes run as the right user)
+# Install bash for the entry script (and because it's generally useful)
+# Install curl to download glide
+# Install git for fetching Go dependencies
+# Install ssh for fetching Go dependencies
+# Install mercurial for fetching go dependencies
+# Install wget for fetching glibc
+# Install make for building things
+# Install util-linux for column command (used for output formatting).
+RUN apk add --no-cache su-exec \
+  bash \
+  curl \
+  git \
+  make \
+  mercurial \
+  openssh \
+  util-linux \
+  wget
+
+# Disable ssh host key checking
+RUN echo 'Host *' >> /etc/ssh/ssh_config \
+  && echo '    StrictHostKeyChecking no' >> /etc/ssh/ssh_config
+
+# Install glibc
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub \
+  && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk \
+  && apk add glibc-2.23-r3.apk
+
+# Disable cgo so that binaries we build will be fully static
+ENV CGO_ENABLED=0
+
+# Apply patches to Go runtime and recompile
+# See https://github.com/golang/go/issues/5838 for defails of vfork patch
+
+# Recompile the standard library with cgo disabled.
+# This prevents the standard library from being marked stale,
+# causing full rebuilds every time.
+RUN go install -v std
+
+# Install glide
+RUN go get github.com/Masterminds/glide
+ENV GLIDE_HOME /home/user/.glide
+
+# Install ginkgo CLI tool for running tests
+RUN go get github.com/onsi/ginkgo/ginkgo
+
+# Install linting tools
+RUN go get -u gopkg.in/alecthomas/gometalinter.v1 \
+  && ln -s $(which gometalinter.v1) /usr/local/bin/gometalinter \
+  && gometalinter --install
+
+# Install license checking tool
+RUN go get github.com/pmezard/licenses
+
+# Install tool to merge coverage reports
+RUN go get github.com/wadey/gocovmerge
+
+
+# Install patched version of goveralls (upstream is bugged if not used from Travis).
+RUN go get -u -d github.com/fasaxc/goveralls && \
+    go get golang.org/x/tools/cover && \
+    go get golang.org/x/net/html && \
+    go get golang.org/x/net/websocket && \
+    go get github.com/stretchr/testify/assert && \
+    go get golang.org/x/text/encoding && \
+    go get golang.org/x/crypto/ssh/terminal && \
+    cd /go/src/github.com/fasaxc/goveralls && \
+    git checkout tags/v0.0.1-smc && \
+    go install github.com/fasaxc/goveralls
+
+# Ensure that everything under the GOPATH is writable by everyone
+RUN chmod -R 777 $GOPATH
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,6 @@ calico/go-build:
 
 calico/go-build-ppc64le:
 	docker build --pull -t calico/go-build-ppc64le -f Dockerfile.ppc64le .
+
+calico/go-build-arm64:
+	docker build --pull -t calico/go-build-arm64 -f Dockerfile.arm64 .


### PR DESCRIPTION
Makefile is updated to add a build command for arm64
Add a Dockerfile.arm64 for arm64 docker image building.

Signed-off-by: Trevor Tao <trevor.tao@arm.com>