### PR TITLE
Add qemu-user-static into the amd64 go-build container.

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -10,7 +10,7 @@ MAINTAINER Tom Denham <tom@projectcalico.org>
 # Install wget for fetching glibc
 # Install make for building things
 # Install util-linux for column command (used for output formatting).
-RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux docker tini
+RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux docker tini file
 RUN apk upgrade --no-cache
 
 # Disable ssh host key checking
@@ -58,6 +58,14 @@ RUN go get github.com/mikefarah/yaml
 RUN wget https://github.com/fasaxc/goveralls/releases/download/v0.0.1-smc/goveralls && \
     chmod +x goveralls && \
     mv goveralls /usr/bin/
+
+# Install qemu user static for all our supported architectures.
+COPY bin/qemu-*-static /usr/bin/
+
+# When running cross built binaries run-times will be auto-installed,
+# insure the install directory is writable by everyone.
+RUN mkdir -m +w -p /usr/local/go/pkg/linux_ppc64le
+RUN mkdir -m +w -p /usr/local/go/pkg/linux_arm64
 
 # Ensure that everything under the GOPATH is writable by everyone
 RUN chmod -R 777 $GOPATH

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -10,6 +10,11 @@ MAINTAINER Trevor Tao <trevor.tao@arm.com>
 # Install wget for fetching glibc
 # Install make for building things
 # Install util-linux for column command (used for output formatting).
+
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be positioned as the first executable command in this file! 
+COPY  bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
 RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux docker tini
 RUN apk upgrade --no-cache
 

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -10,6 +10,11 @@ MAINTAINER David Wilder <wilder@ibm.com>
 # Install wget for fetching glibc
 # Install make for building things
 # Install util-linux for column command (used for output formatting).
+
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be positioned as the first executable command in this file! 
+COPY  bin/qemu-ppc64le-static /usr/bin/qemu-ppc64le-static
+
 RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini
 RUN apk upgrade --no-cache
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@ else
 maybedefault:
 endif
 
+.PHONY: register
+# Enable binfmt adding support for miscellaneous binary formats.  This is needed for building non-native images.
+register:
+	sudo docker run --rm --privileged multiarch/qemu-user-static:register || true
+
 bin/qemu-ppc64le-static:
 	mkdir bin || true
 	wget https://github.com/multiarch/qemu-user-static/releases/download/v2.9.1/qemu-ppc64le-static.tar.gz 
@@ -35,7 +40,7 @@ bin/qemu-aarch64-static:
 
 build: calico/go-build 
 
-calico/go-build: bin/qemu-ppc64le-static bin/qemu-aarch64-static
+calico/go-build: bin/qemu-ppc64le-static bin/qemu-aarch64-static register
 	# Make sure we re-pull the base image to pick up security fixes.
 	docker build --pull -t $(ARCHIMAGE) -f $(DOCKERFILE) .
 

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,21 @@ else
 maybedefault:
 endif
 
-build: calico/go-build
+bin/qemu-ppc64le-static:
+	mkdir bin || true
+	wget https://github.com/multiarch/qemu-user-static/releases/download/v2.9.1/qemu-ppc64le-static.tar.gz 
+	tar zxvf qemu-ppc64le-static.tar.gz -C bin
+	rm qemu-ppc64le-static.tar.gz
 
-calico/go-build:
+bin/qemu-aarch64-static:
+	mkdir bin || true
+	wget https://github.com/multiarch/qemu-user-static/releases/download/v2.9.1-1/qemu-aarch64-static.tar.gz 
+	tar zxvf qemu-aarch64-static.tar.gz -C bin
+	rm qemu-aarch64-static.tar.gz
+
+build: calico/go-build 
+
+calico/go-build: bin/qemu-ppc64le-static bin/qemu-aarch64-static
 	# Make sure we re-pull the base image to pick up security fixes.
 	docker build --pull -t $(ARCHIMAGE) -f $(DOCKERFILE) .
 
@@ -38,3 +50,5 @@ defaulttarget:
 	docker tag $(ARCHIMAGE) $(DEFAULTIMAGE)
 	docker push $(DEFAULTIMAGE)
 
+clean:
+	rm -rif bin

--- a/README.md
+++ b/README.md
@@ -24,3 +24,21 @@ As of this writing, the only way to create such manifests is using the [manifest
 
 Until such time as the `docker manifest` is ready, or we decide to use `manifest-tool`, the default image name will point to `amd64`. Thus, `calico/go-build:latest` refers to `calico/go-build:latest-amd64`.
 
+
+## Cross building using go-build:
+
+Ppc64le and arm64 are supported for cross-building. This example assumes you are running on an amd64/linux system.
+
+Register qemu-*-static for all supported processors except the current one using the following command:
+
+```
+sudo docker run --rm --privileged multiarch/qemu-user-static:register
+```
+
+Specify the target arch by setting GOARCH.
+
+```
+docker run -e GOARCH=<somearch> calico/go-build:latest-amd64 sh -c 'go build hello.go || ./hello'
+```
+
+If a cross built binary is executed in the go-build container qemu-static will automatically be used.


### PR DESCRIPTION
You can cross-build golang applications by setting GOARCH=<somearch>,
However, we often need to execute the resulted binary as part of the
build process, here we use qmeu-user-static as the interpreter.  Both
ppc64le and aarm64 qmeu interpreters are installed into the amd64 image.
I also create a writable directory for golang to install the arch
run-times when needed.

Signed-off-by: David Wilder <wilder@us.ibm.com>