### PR TITLE
cross-compile support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+hello-*

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,5 +1,8 @@
-FROM golang:1.9.2-alpine3.6
+FROM amd64/golang:1.9.2-alpine3.6
 MAINTAINER Tom Denham <tom@projectcalico.org>
+
+ARG QEMU_VERSION=2.9.1-1
+ARG CROSS_ARCHS="aarch64 ppc64le"
 
 # Install su-exec for use in the entrypoint.sh (so processes run as the right user)
 # Install bash for the entry script (and because it's generally useful)
@@ -10,7 +13,7 @@ MAINTAINER Tom Denham <tom@projectcalico.org>
 # Install wget for fetching glibc
 # Install make for building things
 # Install util-linux for column command (used for output formatting).
-RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux docker tini
+RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux docker tini file
 RUN apk upgrade --no-cache
 
 # Disable ssh host key checking
@@ -58,6 +61,16 @@ RUN go get github.com/mikefarah/yaml
 RUN wget https://github.com/fasaxc/goveralls/releases/download/v0.0.1-smc/goveralls && \
     chmod +x goveralls && \
     mv goveralls /usr/bin/
+
+# Enable non-native runs on amd64 architecture hosts
+RUN for i in ${CROSS_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
+RUN chmod +x /usr/bin/qemu-*
+
+# When running cross built binaries run-times will be auto-installed,
+# ensure the install directory is writable by everyone.
+RUN mkdir -m +w -p /usr/local/go/pkg/linux_ppc64le
+RUN mkdir -m +w -p /usr/local/go/pkg/linux_arm64
+
 
 # Ensure that everything under the GOPATH is writable by everyone
 RUN chmod -R 777 $GOPATH

--- a/hello.go
+++ b/hello.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello world")
+}


### PR DESCRIPTION
Add support **just on amd64** to cross-compile to other supported architectures, notably `arm64` and `ppc64le`. Also add documentation to the `README.md`.

Cross-compiling _from_ other architectures is not supported.

Ideally, we never would need to cross-compile, just build arm64 on arm64, amd64 on amd64, ppc64le on ppc64le, etc. However, with an automated CI toolchain, we need the ability to build all platforms automatically. This does not work since almost no CI-as-a-service offers more than amd64. Thus, we prepare for cross-compile.

This image has been tested with felix, see the other PR referencing this one from felix.

**Note:** I am not wholly convinced that we need `qemu-*-static` in the build container. Since we do not _run_ the cross-compiled image, only _build_ it, it should not matter. However, it is easier with the dependency there.

Fixes: https://github.com/projectcalico/go-build/issues/24