### PR TITLE
Cross build go-build and push manifest

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,7 +1,22 @@
+FROM alpine:3.7 as qemu
+
+ARG QEMU_VERSION=2.9.1-1
+ARG CROSS_ARCHS="aarch64 ppc64le"
+
+RUN apk --update add curl
+
+# Enable non-native runs on amd64 architecture hosts
+RUN for i in ${CROSS_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
+RUN chmod +x /usr/bin/qemu-*
+
 FROM arm64v8/golang:1.10.1-alpine3.7
 MAINTAINER Trevor Tao <trevor.tao@arm.com>
 
 ARG MANIFEST_TOOL_VERSION=v0.7.0
+
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
+COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 
 # Install su-exec for use in the entrypoint.sh (so processes run as the right user)
 # Install bash for the entry script (and because it's generally useful)

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,7 +1,22 @@
+FROM alpine:3.7 as qemu
+
+ARG QEMU_VERSION=2.9.1-1
+ARG CROSS_ARCHS="aarch64 ppc64le"
+
+RUN apk --update add curl
+
+# Enable non-native runs on amd64 architecture hosts
+RUN for i in ${CROSS_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
+RUN chmod +x /usr/bin/qemu-*
+
 FROM ppc64le/golang:1.10.1-alpine3.7
 MAINTAINER David Wilder <wilder@ibm.com>
 
 ARG MANIFEST_TOOL_VERSION=v0.7.0
+
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
+COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 
 # Install su-exec for use in the entrypoint.sh (so processes run as the right user)
 # Install bash for the entry script (and because it's generally useful)


### PR DESCRIPTION
This will build all supported architectures(amd64, arm64 and ppc64le) docker images on x86 platform and push manifest for the same.

1. Use multistage build (Required Docker 17.05 or higher)
2. Included following make targets:

  - `all-push` - for pushing docker images for all the supported architecture
  - `all-build` - docker docker image for all the supported architecture
  - `push-manifest` - push manifest image, `all-push` should be run before this target.

The typical release should run - `make all-push push-manifest`