### PR TITLE
Remove glibc.

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -10,7 +10,7 @@ ARG CROSS_ARCHS="aarch64 ppc64le s390x"
 # Install git for fetching Go dependencies
 # Install ssh for fetching Go dependencies
 # Install mercurial for fetching go dependencies
-# Install wget for fetching glibc
+# Install wget since it's useful for fetching
 # Install make for building things
 # Install util-linux for column command (used for output formatting).
 RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux docker tini file
@@ -19,11 +19,6 @@ RUN apk upgrade --no-cache
 # Disable ssh host key checking
 RUN echo 'Host *' >> /etc/ssh/ssh_config
 RUN echo '    StrictHostKeyChecking no' >> /etc/ssh/ssh_config
-
-# Install glibc
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub
-RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk
-RUN apk add glibc-2.23-r3.apk
 
 # Disable cgo so that binaries we build will be fully static.
 ENV CGO_ENABLED=0

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -7,7 +7,7 @@ MAINTAINER Trevor Tao <trevor.tao@arm.com>
 # Install git for fetching Go dependencies
 # Install ssh for fetching Go dependencies
 # Install mercurial for fetching go dependencies
-# Install wget for fetching glibc
+# Install wget since it's useful for fetching
 # Install make for building things
 # Install util-linux for column command (used for output formatting).
 RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux docker tini
@@ -16,11 +16,6 @@ RUN apk upgrade --no-cache
 # Disable ssh host key checking
 RUN echo 'Host *' >> /etc/ssh/ssh_config \
   && echo '    StrictHostKeyChecking no' >> /etc/ssh/ssh_config
-
-# Install glibc
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub \
-  && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk \
-  && apk add glibc-2.23-r3.apk
 
 # Disable cgo so that binaries we build will be fully static.
 ENV CGO_ENABLED=0

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -7,7 +7,7 @@ MAINTAINER David Wilder <wilder@ibm.com>
 # Install git for fetching Go dependencies
 # Install ssh for fetching Go dependencies
 # Install mercurial for fetching go dependencies
-# Install wget for fetching glibc
+# Install wget since it's useful for fetching
 # Install make for building things
 # Install util-linux for column command (used for output formatting).
 RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini
@@ -16,11 +16,6 @@ RUN apk upgrade --no-cache
 # Disable ssh host key checking
 RUN echo 'Host *' >> /etc/ssh/ssh_config
 RUN echo '    StrictHostKeyChecking no' >> /etc/ssh/ssh_config
-
-# Install glibc
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub
-RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk
-RUN apk add glibc-2.23-r3.apk
 
 # Disable cgo so that binaries we build will be fully static.
 ENV CGO_ENABLED=0

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -7,7 +7,7 @@ MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/communi
 # Install git for fetching Go dependencies
 # Install ssh for fetching Go dependencies
 # Install mercurial for fetching go dependencies
-# Install wget for fetching glibc
+# Install wget since it's useful for fetching
 # Install make for building things
 # Install util-linux for column command (used for output formatting).
 RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini
@@ -16,11 +16,6 @@ RUN apk upgrade --no-cache
 # Disable ssh host key checking
 RUN echo 'Host *' >> /etc/ssh/ssh_config
 RUN echo '    StrictHostKeyChecking no' >> /etc/ssh/ssh_config
-
-# Install glibc
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub
-RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk
-RUN apk add glibc-2.23-r3.apk
 
 # Disable cgo so that binaries we build will be fully static.
 ENV CGO_ENABLED=0


### PR DESCRIPTION
- It is no longer needed for Tigera internal builds.
- It causes problems for porting efforts.
- It makes the build smaller.