### PR TITLE
Add manifest-tool to go-build

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -3,6 +3,7 @@ MAINTAINER Tom Denham <tom@projectcalico.org>
 
 ARG QEMU_VERSION=2.9.1-1
 ARG CROSS_ARCHS="aarch64 ppc64le s390x"
+ARG MANIFEST_TOOL_VERSION=v0.7.0
 
 # Install su-exec for use in the entrypoint.sh (so processes run as the right user)
 # Install bash for the entry script (and because it's generally useful)
@@ -66,6 +67,10 @@ RUN for arch in ${CROSS_ARCHS}; do mkdir -m +w -p /usr/local/go/pkg/linux_${arch
 
 # Ensure that everything under the GOPATH is writable by everyone
 RUN chmod -R 777 $GOPATH
+
+RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-amd64 > manifest-tool && \
+    chmod +x manifest-tool && \
+    mv manifest-tool /usr/bin/
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,6 +1,8 @@
 FROM arm64v8/golang:1.10.1-alpine3.7
 MAINTAINER Trevor Tao <trevor.tao@arm.com>
 
+ARG MANIFEST_TOOL_VERSION=v0.7.0
+
 # Install su-exec for use in the entrypoint.sh (so processes run as the right user)
 # Install bash for the entry script (and because it's generally useful)
 # Install curl to download glide
@@ -62,6 +64,10 @@ RUN go get -u -d github.com/fasaxc/goveralls && \
 
 # Ensure that everything under the GOPATH is writable by everyone
 RUN chmod -R 777 $GOPATH
+
+RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-arm64 > manifest-tool && \
+    chmod +x manifest-tool && \
+    mv manifest-tool /usr/bin/
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,6 +1,8 @@
 FROM ppc64le/golang:1.10.1-alpine3.7
 MAINTAINER David Wilder <wilder@ibm.com>
 
+ARG MANIFEST_TOOL_VERSION=v0.7.0
+
 # Install su-exec for use in the entrypoint.sh (so processes run as the right user)
 # Install bash for the entry script (and because it's generally useful)
 # Install curl to download glide
@@ -56,6 +58,10 @@ RUN go get -u -d github.com/fasaxc/goveralls && \
 
 # Ensure that everything under the GOPATH is writable by everyone
 RUN chmod -R 777 $GOPATH
+
+RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-ppc64le > manifest-tool && \
+    chmod +x manifest-tool && \
+    mv manifest-tool /usr/bin/
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,6 +1,8 @@
 FROM s390x/golang:1.10.1-alpine3.7
 MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
 
+ARG MANIFEST_TOOL_VERSION=v0.7.0
+
 # Install su-exec for use in the entrypoint.sh (so processes run as the right user)
 # Install bash for the entry script (and because it's generally useful)
 # Install curl to download glide
@@ -55,6 +57,10 @@ RUN go get -u -d github.com/fasaxc/goveralls && \
 
 # Ensure that everything under the GOPATH is writable by everyone
 RUN chmod -R 777 $GOPATH
+
+RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-s390x > manifest-tool && \
+    chmod +x manifest-tool && \
+    mv manifest-tool /usr/bin/
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
Add manifest-tool to build manifest images for all the calico docker images.

Reference - https://github.com/projectcalico/felix/pull/1746#discussion_r181006729