### PR TITLE
Revert to upstream goveralls.

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -51,10 +51,8 @@ RUN go get github.com/wadey/gocovmerge
 # Install CLI tool for working with yaml files
 RUN go get github.com/mikefarah/yaml
 
-# Install patched version of goveralls (upstream is bugged if not used from Travis).
-RUN wget https://github.com/fasaxc/goveralls/releases/download/v0.0.1-smc/goveralls && \
-    chmod +x goveralls && \
-    mv goveralls /usr/bin/
+# Install goveralls
+RUN go get github.com/mattn/goveralls
 
 # Enable non-native runs on amd64 architecture hosts
 RUN for i in ${CROSS_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -48,17 +48,8 @@ RUN go get github.com/wadey/gocovmerge
 # Install CLI tool for working with yaml files
 RUN go get github.com/mikefarah/yaml
 
-# Install patched version of goveralls (upstream is bugged if not used from Travis).
-RUN go get -u -d github.com/fasaxc/goveralls && \
-    go get golang.org/x/tools/cover && \
-    go get golang.org/x/net/html && \
-    go get golang.org/x/net/websocket && \
-    go get github.com/stretchr/testify/assert && \
-    go get golang.org/x/text/encoding && \
-    go get golang.org/x/crypto/ssh/terminal && \
-    cd /go/src/github.com/fasaxc/goveralls && \
-    git checkout tags/v0.0.1-smc && \
-    go install github.com/fasaxc/goveralls
+# Install goveralls
+RUN go get github.com/mattn/goveralls
 
 # Ensure that everything under the GOPATH is writable by everyone
 RUN chmod -R 777 $GOPATH

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -48,11 +48,8 @@ RUN go get github.com/wadey/gocovmerge
 # Install CLI tool for working with yaml files
 RUN go get github.com/mikefarah/yaml
 
-# Install patched version of goveralls (upstream is bugged if not used from Travis).
-RUN go get -u -d github.com/fasaxc/goveralls && \
-    cd /go/src/github.com/fasaxc/goveralls && \
-    git checkout tags/v0.0.1-smc && \
-    go install github.com/fasaxc/goveralls
+# Install goveralls
+RUN go get github.com/mattn/goveralls
 
 # Ensure that everything under the GOPATH is writable by everyone
 RUN chmod -R 777 $GOPATH

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -47,11 +47,8 @@ RUN go get github.com/wadey/gocovmerge
 
 RUN go get github.com/mikefarah/yaml
 
-# Install patched version of goveralls (upstream is bugged if not used from Travis).
-RUN go get -u -d github.com/fasaxc/goveralls && \
-    cd /go/src/github.com/fasaxc/goveralls && \
-    git checkout tags/v0.0.1-smc && \
-    go install github.com/fasaxc/goveralls
+# Install goveralls
+RUN go get github.com/mattn/goveralls
 
 # Ensure that everything under the GOPATH is writable by everyone
 RUN chmod -R 777 $GOPATH


### PR DESCRIPTION
- Fixes build, which was relying on wrong libc.
- Upstream is now fixed so fork is no longer required.

I've done a test build of felix UTs and coverage upload with this commit.  Seemed to work fine.

Fixes #38 