### PR TITLE
Fix CROSS_ARCHS for golang

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -2,7 +2,13 @@ FROM amd64/golang:1.10.1-alpine3.7
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
 ARG QEMU_VERSION=2.9.1-1
-ARG CROSS_ARCHS="aarch64 ppc64le s390x"
+
+# we need these two distinct lists. The first one is the names used by the qemu distributions
+# these second is the names used by golang see https://github.com/golang/go/blob/master/src/go/build/syslist.go
+# the primary difference as of this writing is that qemu uses aarch64 and golang uses arm64
+ARG QEMU_ARCHS="aarch64 ppc64le s390x"
+ARG CROSS_ARCHS="arm64 ppc64le s390x"
+
 ARG MANIFEST_TOOL_VERSION=v0.7.0
 
 # Install su-exec for use in the entrypoint.sh (so processes run as the right user)
@@ -56,7 +62,7 @@ RUN go get github.com/mikefarah/yaml
 RUN go get github.com/mattn/goveralls
 
 # Enable non-native runs on amd64 architecture hosts
-RUN for i in ${CROSS_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
+RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
 # When running cross built binaries run-times will be auto-installed,


### PR DESCRIPTION
The commit [here](https://github.com/projectcalico/go-build/commit/883b931c405a7d81541b9ce23b03283a4c07019b#diff-c8b09f88c044c3dec6a30981db2282e9) replaced the explicit `mkdir /usr/local/go/pkg/linux_<arch>` for each arch with the list from `CROSS_ARCHS` in `Dockerfile.amd64`. Unfortunately, `CROSS_ARCHS` was tailored for the `qemu` arch names, which use `aarch64`, and not the golang ones, which use `arm64`.

That merge makes `v0.12` break for all `arm64` builds.

This PR fixes it.