### PR TITLE
Sync packages between Dockerfiles.

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -12,7 +12,7 @@ ARG MANIFEST_TOOL_VERSION=v0.7.0
 # Install wget since it's useful for fetching
 # Install make for building things
 # Install util-linux for column command (used for output formatting).
-RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux docker tini
+RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux file docker tini
 RUN apk upgrade --no-cache
 
 # Disable ssh host key checking

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -12,7 +12,7 @@ ARG MANIFEST_TOOL_VERSION=v0.7.0
 # Install wget since it's useful for fetching
 # Install make for building things
 # Install util-linux for column command (used for output formatting).
-RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini
+RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux file docker tini
 RUN apk upgrade --no-cache
 
 # Disable ssh host key checking

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -12,7 +12,7 @@ ARG MANIFEST_TOOL_VERSION=v0.7.0
 # Install wget since it's useful for fetching
 # Install make for building things
 # Install util-linux for column command (used for output formatting).
-RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini
+RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux file docker tini
 RUN apk upgrade --no-cache
 
 # Disable ssh host key checking


### PR DESCRIPTION
Add the docker and file packages into all Dockerfiles.

The list of packages installed had become inconsistent between architecture. Not all architectures were installing docker and file.  The docker command is used for some unit tests.  File is helpful when working with cross arch images.

Signed-off-by: David Wilder <wilder@us.ibm.com>