### PR TITLE
Add pre-built stdlib for cross-compile platforms

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -67,7 +67,7 @@ RUN chmod +x /usr/bin/qemu-*
 
 # When running cross built binaries run-times will be auto-installed,
 # ensure the install directory is writable by everyone.
-RUN for arch in ${CROSS_ARCHS}; do mkdir -m +w -p /usr/local/go/pkg/linux_${arch}; done
+RUN for arch in ${CROSS_ARCHS}; do mkdir -m +w -p /usr/local/go/pkg/linux_${arch}; GOARCH=${arch} go install -v std; done
 
 # Ensure that everything under the GOPATH is writable by everyone
 RUN chmod -R 777 $GOPATH

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ sub-build-%:
 
 build: calico/go-build
 
+image: calico/go-build
 calico/go-build: register
 	# Make sure we re-pull the base image to pick up security fixes.
 	# Limit the build to use only one CPU, This helps to work around qemu bugs such as https://bugs.launchpad.net/qemu/+bug/1098729


### PR DESCRIPTION
As pointed out in #45 , cross compiles are slow because it needs to build the stdlib components. This pre-builds it in for all supported cross-compile archs. 

Also adds standard `image` target to `Makefile`.

cc @fasaxc 