### PR TITLE
Document how to use binfmt for calico projects; fix s390x usage of it

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,12 +1,12 @@
 FROM alpine:3.7 as qemu
 
 ARG QEMU_VERSION=2.9.1-1
-ARG CROSS_ARCHS="aarch64 ppc64le"
+ARG QEMU_ARCHS="aarch64"
 
 RUN apk --update add curl
 
 # Enable non-native runs on amd64 architecture hosts
-RUN for i in ${CROSS_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
+RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
 FROM arm64v8/golang:1.10.1-alpine3.7

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,12 +1,12 @@
 FROM alpine:3.7 as qemu
 
 ARG QEMU_VERSION=2.9.1-1
-ARG CROSS_ARCHS="aarch64 ppc64le"
+ARG QEMU_ARCHS="ppc64le"
 
 RUN apk --update add curl
 
 # Enable non-native runs on amd64 architecture hosts
-RUN for i in ${CROSS_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
+RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
 FROM ppc64le/golang:1.10.1-alpine3.7

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,7 +1,22 @@
+FROM alpine:3.7 as qemu
+
+ARG QEMU_VERSION=2.9.1-1
+ARG QEMU_ARCHS="s390x"
+
+RUN apk --update add curl
+
+# Enable non-native runs on amd64 architecture hosts
+RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
+RUN chmod +x /usr/bin/qemu-*
+
 FROM s390x/golang:1.10.1-alpine3.7
 MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
 
 ARG MANIFEST_TOOL_VERSION=v0.7.0
+
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
+COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 
 # Install su-exec for use in the entrypoint.sh (so processes run as the right user)
 # Install bash for the entry script (and because it's generally useful)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,54 @@ docker run -e GOARCH=<somearch> calico/go-build:latest-amd64 sh -c 'go build hel
 
 The above will output a binary `hello` built for the architecture `<somearch>`.
 
+## Cross-runnning Binaries binfmt
+The Linux kernel has the ability to run binaries built for one arch on another, e.g. `arm64` binaries on an `amd64` architecture. Support requires two things:
+
+1. Registering an interpeter that can run the binary for the other architecture along with configuration information on how to identify which binaries are for which platform and which emulator will handle them.
+2. Making the interpreter binary available.
+
+The interpreter must exist in one of two places:
+
+* The container where you are running the other-architecture binary. 
+* The container where you run registration, if you pass the correct flag during registration. This is supported **only** from Linux kernel version 4.8+.
+
+For example, if you registered the `s390x` emulator at `/usr/bin/qemu-s390x-static`, and then wanted to run `docker run -it --rm s390x/alpine:3.7 sh` on an `amd64`, it wouldn't work in the first method, because the new container doesn't have an emulator in it. However, if you followed the second method, it would work, since the kernel already found and loaded the emulator. This works **even if you delete the registration container.**
+
+To register emulators, we run:
+
+```
+docker run -it --rm --privileged multiarch/qemu-user-static:register
+```
+
+or simply
+
+```
+make register
+```
+
+After the above registration, your system can handle other-architecture binaries. The above registration uses the first method, since _all_ kernels that support `binfmt` support this method, while only kernels from version 4.8+ support the latter. While docker-for-mac and docker-for-windows both use supporting kernels, almost every CI-as-a-service does not.
+
+## Using binfmt in other Calico projects
+To use `binfmt` in other projects:
+
+1. Ensure you have run registration as above.
+2. Copy the correct interpreter into the container in which you will run other-architecture commands. The `COPY` **must** be before _any_ `RUN` command.
+
+```dockerfile
+FROM calico/go-build:v0.16 as qemu
+
+FROM arm64v8/alpine:3.8 as base
+
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
+# we only need this for the intermediate "base" image, so we can run all the apk and other commands
+COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
+
+# now we can do all our RUN commands
+RUN apk --update add curl
+# etc
+```
+
 ## Running a Binary
 To *run* a binary from a different architecture, you need to use `binfmt` and `qemu` static. 
 


### PR DESCRIPTION
We already had all of the `qemu` static binaries installed in our `go-build` environment. This adds the 2 files (script and config) necessary to register support for them via `binfmt`.

Once this is done, you can run:

```
docker run -it --rm --privileged --entrypoint=/usr/local/bin/register calico/go-build:<version>
```

and you then will be able to run binaries for alternate architectures. 

Once this is in (and part of a release), will change the `register` target (which wasn't working) on the other projects that require it for building images.

Fixes what is broken in the cross-image [here](https://github.com/projectcalico/felix/pull/1852)

cc @fasaxc @tomdee @caseydavenport @mkumatag 