### PR TITLE
rev fossa-cli to latest v0.7.14

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -26,7 +26,7 @@ RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-li
 RUN apk upgrade --no-cache
 
 # Install fossa for foss license checks
-ARG FOSSA_VER=0.7.8
+ARG FOSSA_VER=0.7.14
 RUN curl -L https://github.com/fossas/fossa-cli/releases/download/v${FOSSA_VER}/fossa-cli_${FOSSA_VER}_linux_amd64.tar.gz | tar zxvf - -C /usr/local/bin --extract fossa
 RUN chmod +x /usr/local/bin/fossa
 


### PR DESCRIPTION
Rev fossa-cli to current. It has a variety of bug fixes

# validation
* build it locally
```
docker run --rm go-build:et-rev-fossa-0.7.14 /usr/local/bin/fossa -version
Starting with UID : 9001
fossa-cli version 0.7.14 (revision 4821bdccd1ebffa72f69ae887a7b561803ba77b4 compiled with go version go1.11 linux/amd64)
```