### PR TITLE
Replace adduser with useradd

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -22,7 +22,8 @@ ARG MANIFEST_TOOL_VERSION=v0.7.0
 # Install util-linux for column command (used for output formatting).
 # Install grep and sed for use in some Makefiles (e.g. pulling versions out of glide.yaml)
 # Install libc6-compat for fossa client
-RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed libc6-compat
+# Install shadow for useradd (it allows to use big UID)
+RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed libc6-compat shadow
 RUN apk upgrade --no-cache
 
 # Install fossa for foss license checks

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -28,7 +28,8 @@ COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 # Install make for building things
 # Install util-linux for column command (used for output formatting).
 # Install grep and sed for use in some Makefiles (e.g. pulling versions out of glide.yaml)
-RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed
+# Install shadow for useradd (it allows to use big UID)
+RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed shadow
 RUN apk upgrade --no-cache
 
 # Disable ssh host key checking

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -28,7 +28,8 @@ COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 # Install make for building things
 # Install util-linux for column command (used for output formatting).
 # Install grep and sed for use in some Makefiles (e.g. pulling versions out of glide.yaml)
-RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed
+# Install shadow for useradd (it allows to use big UID)
+RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed shadow
 RUN apk upgrade --no-cache
 
 # Disable ssh host key checking

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -28,7 +28,8 @@ COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 # Install make for building things
 # Install util-linux for column command (used for output formatting).
 # Install grep and sed for use in some Makefiles (e.g. pulling versions out of glide.yaml)
-RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed
+# Install shadow for useradd (it allows to use big UID)
+RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed shadow
 RUN apk upgrade --no-cache
 
 # Disable ssh host key checking

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,9 @@
 USER_ID=${LOCAL_USER_ID:-9001}
 
 echo "Starting with UID : $USER_ID" 1>&2
-adduser -D -s /bin/bash -u $USER_ID -g "" user
+# Do not create mail box.
+/bin/sed -i 's/^CREATE_MAIL_SPOOL=yes/CREATE_MAIL_SPOOL=no/' /etc/default/useradd
+/usr/sbin/useradd -U -s /bin/bash -u $USER_ID user
 export HOME=/home/user
 
 if [ -n "$EXTRA_GROUP_ID"  ]; then


### PR DESCRIPTION
This PR replace alpine's `adduser` command with the `useradd` command from `shadow` package.
The latest does not have a limit on UID. See details in the issue.

Fixes https://github.com/projectcalico/go-build/issues/64