### PR TITLE
bump version of go from 1.11.2 => 1.11.9

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.11.2-alpine3.8
+FROM amd64/golang:1.11.9-alpine3.8
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
 ARG QEMU_VERSION=2.9.1-1

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm64v8/golang:1.11.2-alpine3.8
+FROM arm64v8/golang:1.11.9-alpine3.8
 MAINTAINER Trevor Tao <trevor.tao@arm.com>
 
 ARG MANIFEST_TOOL_VERSION=v0.7.0

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM ppc64le/golang:1.11.2-alpine3.8
+FROM ppc64le/golang:1.11.9-alpine3.8
 MAINTAINER David Wilder <wilder@ibm.com>
 
 ARG MANIFEST_TOOL_VERSION=v0.7.0

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM s390x/golang:1.11.2-alpine3.8
+FROM s390x/golang:1.11.9-alpine3.8
 MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
 
 ARG MANIFEST_TOOL_VERSION=v0.7.0


### PR DESCRIPTION
This bumps us to Go 1.11.9, the current latest 1.11 release.

There are a few reasons for this change:
1. Adds the new `-race` flag optionally for tests
1. Newer `net/http/httputil` pkg for the reverse proxy
1. Go 1.11 through Go 1.11.3 have an issue importing Logrus when using go modules

The go module `golang.org/x/sys` now explicitly requires go 1.12 in its `go.mod` file. So if using go modules to import logrus (which imports golang.org/x/sys) you'll likely see this message:

`go build golang.org/x/sys/unix: module requires Go 1.12`

As per the docs fix from that issue:

> This changed use of the <code>go</code> directive means that if you
  use Go 1.12 to build a module, thus recording <code>go 1.12</code>
  in the <code>go.mod</code> file, you will get an error when
  attempting to build the same module with Go 1.11 through Go 1.11.3.
  Go 1.11.4 or later will work fine, as will releases older than Go 1.11.
  If you must use Go 1.11 through 1.11.3, you can avoid the problem by
  setting the language version to 1.11, using the Go 1.12 go tool,
  via <code>go mod edit -go=1.11</code>.