### PR TITLE
Upgrade to go 1.12

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.11.9-alpine3.8
+FROM amd64/golang:1.12.6-alpine3.9
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
 ARG QEMU_VERSION=2.9.1-1
@@ -23,6 +23,7 @@ ARG MANIFEST_TOOL_VERSION=v0.7.0
 # Install grep and sed for use in some Makefiles (e.g. pulling versions out of glide.yaml)
 # Install libc6-compat for fossa client
 # Install shadow for useradd (it allows to use big UID)
+RUN apk update && apk upgrade --available
 RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed libc6-compat shadow
 RUN apk upgrade --no-cache
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM alpine:3.8 as qemu
+FROM alpine:3.9 as qemu
 
 ARG QEMU_VERSION=2.9.1-1
 ARG QEMU_ARCHS="aarch64"
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm64v8/golang:1.11.9-alpine3.8
+FROM arm64v8/golang:1.12.6-alpine3.9
 MAINTAINER Trevor Tao <trevor.tao@arm.com>
 
 ARG MANIFEST_TOOL_VERSION=v0.7.0
@@ -29,7 +29,7 @@ COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 # Install util-linux for column command (used for output formatting).
 # Install grep and sed for use in some Makefiles (e.g. pulling versions out of glide.yaml)
 # Install shadow for useradd (it allows to use big UID)
-RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed shadow
+RUN apk update && apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed shadow
 RUN apk upgrade --no-cache
 
 # Disable ssh host key checking

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,4 +1,4 @@
-FROM alpine:3.8 as qemu
+FROM alpine:3.9 as qemu
 
 ARG QEMU_VERSION=2.9.1-1
 ARG QEMU_ARCHS="ppc64le"
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM ppc64le/golang:1.11.9-alpine3.8
+FROM ppc64le/golang:1.12.6-alpine3.9
 MAINTAINER David Wilder <wilder@ibm.com>
 
 ARG MANIFEST_TOOL_VERSION=v0.7.0
@@ -29,7 +29,7 @@ COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 # Install util-linux for column command (used for output formatting).
 # Install grep and sed for use in some Makefiles (e.g. pulling versions out of glide.yaml)
 # Install shadow for useradd (it allows to use big UID)
-RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed shadow
+RUN apk update && apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed shadow
 RUN apk upgrade --no-cache
 
 # Disable ssh host key checking


### PR DESCRIPTION
Upgrade go-build images to go 1.12.6 (https://hub.docker.com/_/golang) for amd64, arm64, ppc64le.

s390x will remain with the current configuration as it requires additional changes to the Dockerfile.
Supported arches are: `ARCHES = amd64 arm64 ppc64le`

Ran the following commands: 

```
make all
```

Results of running hello.go:
```
make test
docker run --rm --privileged multiarch/qemu-user-static:register --reset
Setting /usr/bin/qemu-alpha-static as binfmt interpreter for alpha
Setting /usr/bin/qemu-arm-static as binfmt interpreter for arm
Setting /usr/bin/qemu-armeb-static as binfmt interpreter for armeb
Setting /usr/bin/qemu-sparc32plus-static as binfmt interpreter for sparc32plus
Setting /usr/bin/qemu-ppc-static as binfmt interpreter for ppc
Setting /usr/bin/qemu-ppc64-static as binfmt interpreter for ppc64
Setting /usr/bin/qemu-ppc64le-static as binfmt interpreter for ppc64le
Setting /usr/bin/qemu-m68k-static as binfmt interpreter for m68k
Setting /usr/bin/qemu-mips-static as binfmt interpreter for mips
Setting /usr/bin/qemu-mipsel-static as binfmt interpreter for mipsel
Setting /usr/bin/qemu-mipsn32-static as binfmt interpreter for mipsn32
Setting /usr/bin/qemu-mipsn32el-static as binfmt interpreter for mipsn32el
Setting /usr/bin/qemu-mips64-static as binfmt interpreter for mips64
Setting /usr/bin/qemu-mips64el-static as binfmt interpreter for mips64el
Setting /usr/bin/qemu-sh4-static as binfmt interpreter for sh4
Setting /usr/bin/qemu-sh4eb-static as binfmt interpreter for sh4eb
Setting /usr/bin/qemu-s390x-static as binfmt interpreter for s390x
Setting /usr/bin/qemu-aarch64-static as binfmt interpreter for aarch64
Setting /usr/bin/qemu-aarch64_be-static as binfmt interpreter for aarch64_be
Setting /usr/bin/qemu-hppa-static as binfmt interpreter for hppa
Setting /usr/bin/qemu-riscv32-static as binfmt interpreter for riscv32
Setting /usr/bin/qemu-riscv64-static as binfmt interpreter for riscv64
Setting /usr/bin/qemu-xtensa-static as binfmt interpreter for xtensa
Setting /usr/bin/qemu-xtensaeb-static as binfmt interpreter for xtensaeb
Setting /usr/bin/qemu-microblaze-static as binfmt interpreter for microblaze
Setting /usr/bin/qemu-microblazeel-static as binfmt interpreter for microblazeel
Setting /usr/bin/qemu-or1k-static as binfmt interpreter for or1k
for arch in amd64 arm64 ppc64le ; do ARCH=$arch /Library/Developer/CommandLineTools/usr/bin/make testcompile; done
docker run --rm -e LOCAL_USER_ID=501 -e GOARCH=amd64 -w /code -v /Users/alinamilitaru/go/src/github.com/asincu/go-build:/code calico/go-build:latest-amd64 go build -o hello-amd64 hello.go
Starting with UID : 501
docker run --rm -v /Users/alinamilitaru/go/src/github.com/asincu/go-build:/code calico/go-build:latest-amd64 /code/hello-amd64 | grep -q "hello world"
Starting with UID : 9001
success
docker run --rm -e LOCAL_USER_ID=501 -e GOARCH=arm64 -w /code -v /Users/alinamilitaru/go/src/github.com/asincu/go-build:/code calico/go-build:latest-amd64 go build -o hello-arm64 hello.go
Starting with UID : 501
docker run --rm -v /Users/alinamilitaru/go/src/github.com/asincu/go-build:/code calico/go-build:latest-amd64 /code/hello-arm64 | grep -q "hello world"
Starting with UID : 9001
success
docker run --rm -e LOCAL_USER_ID=501 -e GOARCH=ppc64le -w /code -v /Users/alinamilitaru/go/src/github.com/asincu/go-build:/code calico/go-build:latest-amd64 go build -o hello-ppc64le hello.go
Starting with UID : 501
docker run --rm -v /Users/alinamilitaru/go/src/github.com/asincu/go-build:/code calico/go-build:latest-amd64 /code/hello-ppc64le | grep -q "hello world"
Starting with UID : 9001
success
```