### PR TITLE
Replace gometalinter with golangci-lint

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,15 +1,47 @@
+#
+# Build tools and deps.
+#
+FROM amd64/golang:1.12.6-alpine3.9 as build_tools
+RUN apk add --no-cache git curl
+
+# Arch names used by the qemu distributions. The primary difference from CROSS_ARCHS is that qemu uses aarch64 and golang uses arm64.
+ARG QEMU_ARCHS="aarch64 ppc64le s390x"
+ARG QEMU_VERSION=2.9.1-1
+
+# Enable non-native runs on amd64 architecture hosts
+RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
+RUN chmod +x /usr/bin/qemu-*
+
+ARG MANIFEST_TOOL_VERSION=v0.7.0
+
+# Disable cgo so that binaries we build will be fully static.
+ENV CGO_ENABLED=0
+
+RUN go get github.com/Masterminds/glide
+RUN go get github.com/golang/dep/cmd/dep
+RUN go get github.com/onsi/ginkgo/ginkgo
+RUN go get github.com/pmezard/licenses
+RUN go get github.com/wadey/gocovmerge
+RUN go get -u github.com/jstemmer/go-junit-report
+
+RUN go get -u gopkg.in/alecthomas/gometalinter.v2
+RUN ln -s `which gometalinter.v2` /go/bin/gometalinter
+RUN gometalinter --install
+
+RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-amd64 > manifest-tool && \
+    chmod +x manifest-tool
+
+# Install vgo (should be removed once we take Go 1.11)
+RUN go get -u golang.org/x/vgo
+
+#
+# The main image.
+#
 FROM amd64/golang:1.12.6-alpine3.9
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
-ARG QEMU_VERSION=2.9.1-1
-
-# we need these two distinct lists. The first one is the names used by the qemu distributions
-# these second is the names used by golang see https://github.com/golang/go/blob/master/src/go/build/syslist.go
-# the primary difference as of this writing is that qemu uses aarch64 and golang uses arm64
-ARG QEMU_ARCHS="aarch64 ppc64le s390x"
+# Arch names used by golang. See https://github.com/golang/go/blob/master/src/go/build/syslist.go
 ARG CROSS_ARCHS="arm64 ppc64le s390x"
-
-ARG MANIFEST_TOOL_VERSION=v0.7.0
 
 # Install su-exec for use in the entrypoint.sh (so processes run as the right user)
 # Install bash for the entry script (and because it's generally useful)
@@ -43,39 +75,11 @@ ENV CGO_ENABLED=0
 # marked stale, causing full rebuilds every time.
 RUN go install -v std
 
-# Install glide
-RUN go get github.com/Masterminds/glide
 ENV GLIDE_HOME /home/user/.glide
 
-# Install dep
-RUN go get github.com/golang/dep/cmd/dep
-
-# Install ginkgo CLI tool for running tests
-RUN go get github.com/onsi/ginkgo/ginkgo
-
-# Install linting tools.
-RUN go get -u gopkg.in/alecthomas/gometalinter.v2
-RUN ln -s `which gometalinter.v2` /usr/local/bin/gometalinter
-RUN gometalinter --install
-
-# Install license checking tool.
-RUN go get github.com/pmezard/licenses
-
-# Install tool to merge coverage reports.
-RUN go get github.com/wadey/gocovmerge
-
-# Install CLI tool for working with yaml files
-RUN go get github.com/mikefarah/yaml
-
-# Install vgo (should be removed once we take Go 1.11)
-RUN go get -u golang.org/x/vgo
-
-# Install tool to convert go-test output to junit
-RUN go get -u github.com/jstemmer/go-junit-report
-
-# Enable non-native runs on amd64 architecture hosts
-RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
-RUN chmod +x /usr/bin/qemu-*
+# Install prebuilt tools and deps.
+COPY --from=build_tools /go/bin/* /go/bin/
+COPY --from=build_tools /usr/bin/qemu-* /usr/bin/
 
 # When running cross built binaries run-times will be auto-installed,
 # ensure the install directory is writable by everyone.
@@ -86,10 +90,6 @@ RUN rm -rf /go/src/*
 
 # Ensure that everything under the GOPATH is writable by everyone
 RUN chmod -R 777 $GOPATH
-
-RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-amd64 > manifest-tool && \
-    chmod +x manifest-tool && \
-    mv manifest-tool /usr/bin/
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -23,10 +23,7 @@ RUN go get github.com/onsi/ginkgo/ginkgo
 RUN go get github.com/pmezard/licenses
 RUN go get github.com/wadey/gocovmerge
 RUN go get -u github.com/jstemmer/go-junit-report
-
-RUN go get -u gopkg.in/alecthomas/gometalinter.v2
-RUN ln -s `which gometalinter.v2` /go/bin/gometalinter
-RUN gometalinter --install
+RUN GO111MODULE=on go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.1
 
 RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-amd64 > manifest-tool && \
     chmod +x manifest-tool

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -28,9 +28,6 @@ RUN GO111MODULE=on go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-amd64 > manifest-tool && \
     chmod +x manifest-tool
 
-# Install vgo (should be removed once we take Go 1.11)
-RUN go get -u golang.org/x/vgo
-
 #
 # The main image.
 #

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -39,9 +39,6 @@ RUN GO111MODULE=on go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-amd64 > manifest-tool && \
     chmod +x manifest-tool
 
-# Install vgo (should be removed once we take Go 1.11)
-RUN go get -u golang.org/x/vgo
-
 #
 # The main image.
 #

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -34,10 +34,7 @@ RUN go get github.com/onsi/ginkgo/ginkgo
 RUN go get github.com/pmezard/licenses
 RUN go get github.com/wadey/gocovmerge
 RUN go get -u github.com/jstemmer/go-junit-report
-
-RUN go get -u gopkg.in/alecthomas/gometalinter.v2
-RUN ln -s `which gometalinter.v2` /go/bin/gometalinter
-RUN gometalinter --install
+RUN GO111MODULE=on go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.1
 
 RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-amd64 > manifest-tool && \
     chmod +x manifest-tool

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,3 +1,6 @@
+#
+# Build qemu binaries.
+#
 FROM alpine:3.9 as qemu
 
 ARG QEMU_VERSION=2.9.1-1
@@ -9,10 +12,44 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm64v8/golang:1.12.6-alpine3.9
-MAINTAINER Trevor Tao <trevor.tao@arm.com>
+#
+# Build tools and deps.
+#
+FROM arm64v8/golang:1.12.6-alpine3.9 as build_tools
+
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
+COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
+
+RUN apk add --no-cache git curl
 
 ARG MANIFEST_TOOL_VERSION=v0.7.0
+
+# Disable cgo so that binaries we build will be fully static.
+ENV CGO_ENABLED=0
+
+RUN go get github.com/Masterminds/glide
+RUN go get github.com/golang/dep/cmd/dep
+RUN go get github.com/onsi/ginkgo/ginkgo
+RUN go get github.com/pmezard/licenses
+RUN go get github.com/wadey/gocovmerge
+RUN go get -u github.com/jstemmer/go-junit-report
+
+RUN go get -u gopkg.in/alecthomas/gometalinter.v2
+RUN ln -s `which gometalinter.v2` /go/bin/gometalinter
+RUN gometalinter --install
+
+RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-amd64 > manifest-tool && \
+    chmod +x manifest-tool
+
+# Install vgo (should be removed once we take Go 1.11)
+RUN go get -u golang.org/x/vgo
+
+#
+# The main image.
+#
+FROM arm64v8/golang:1.12.6-alpine3.9
+MAINTAINER Trevor Tao <trevor.tao@arm.com>
 
 # Enable non-native builds of this image on an amd64 hosts.
 # This must be the first RUN command in this file!
@@ -29,7 +66,7 @@ COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 # Install util-linux for column command (used for output formatting).
 # Install grep and sed for use in some Makefiles (e.g. pulling versions out of glide.yaml)
 # Install shadow for useradd (it allows to use big UID)
-RUN apk update && apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed shadow
+RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed shadow
 RUN apk upgrade --no-cache
 
 # Disable ssh host key checking
@@ -43,42 +80,16 @@ ENV CGO_ENABLED=0
 # marked stale, causing full rebuilds every time.
 RUN go install -v std
 
-# Install glide
-RUN go get github.com/Masterminds/glide
 ENV GLIDE_HOME /home/user/.glide
 
-# Install dep
-RUN go get github.com/golang/dep/cmd/dep
-
-# Install ginkgo CLI tool for running tests
-RUN go get github.com/onsi/ginkgo/ginkgo
-
-# Install linting tools.
-RUN go get -u gopkg.in/alecthomas/gometalinter.v2
-RUN ln -s `which gometalinter.v2` /usr/local/bin/gometalinter
-RUN gometalinter --install
-
-# Install license checking tool.
-RUN go get github.com/pmezard/licenses
-
-# Install tool to merge coverage reports.
-RUN go get github.com/wadey/gocovmerge
-
-# Install CLI tool for working with yaml files
-RUN go get github.com/mikefarah/yaml
+# Install prebuilt tools and deps.
+COPY --from=build_tools /go/bin/* /go/bin/
 
 # Delete all the Go sources that were downloaded, we only rely on the binaries
 RUN rm -rf /go/src/*
 
-# Install vgo (should be removed once we take Go 1.11)
-RUN go get -u golang.org/x/vgo
-
 # Ensure that everything under the GOPATH is writable by everyone
 RUN chmod -R 777 $GOPATH
-
-RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-arm64 > manifest-tool && \
-    chmod +x manifest-tool && \
-    mv manifest-tool /usr/bin/
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -39,9 +39,6 @@ RUN GO111MODULE=on go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-amd64 > manifest-tool && \
     chmod +x manifest-tool
 
-# Install vgo (should be removed once we take Go 1.11)
-RUN go get -u golang.org/x/vgo
-
 #
 # The main image.
 #

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -34,10 +34,7 @@ RUN go get github.com/onsi/ginkgo/ginkgo
 RUN go get github.com/pmezard/licenses
 RUN go get github.com/wadey/gocovmerge
 RUN go get -u github.com/jstemmer/go-junit-report
-
-RUN go get -u gopkg.in/alecthomas/gometalinter.v2
-RUN ln -s `which gometalinter.v2` /go/bin/gometalinter
-RUN gometalinter --install
+RUN GO111MODULE=on go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.1
 
 RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-amd64 > manifest-tool && \
     chmod +x manifest-tool

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,3 +1,6 @@
+#
+# Build qemu binaries.
+#
 FROM alpine:3.9 as qemu
 
 ARG QEMU_VERSION=2.9.1-1
@@ -9,10 +12,44 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM ppc64le/golang:1.12.6-alpine3.9
-MAINTAINER David Wilder <wilder@ibm.com>
+#
+# Build tools and deps.
+#
+FROM ppc64le/golang:1.12.6-alpine3.9 as build_tools
+
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
+COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
+
+RUN apk add --no-cache git curl
 
 ARG MANIFEST_TOOL_VERSION=v0.7.0
+
+# Disable cgo so that binaries we build will be fully static.
+ENV CGO_ENABLED=0
+
+RUN go get github.com/Masterminds/glide
+RUN go get github.com/golang/dep/cmd/dep
+RUN go get github.com/onsi/ginkgo/ginkgo
+RUN go get github.com/pmezard/licenses
+RUN go get github.com/wadey/gocovmerge
+RUN go get -u github.com/jstemmer/go-junit-report
+
+RUN go get -u gopkg.in/alecthomas/gometalinter.v2
+RUN ln -s `which gometalinter.v2` /go/bin/gometalinter
+RUN gometalinter --install
+
+RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-amd64 > manifest-tool && \
+    chmod +x manifest-tool
+
+# Install vgo (should be removed once we take Go 1.11)
+RUN go get -u golang.org/x/vgo
+
+#
+# The main image.
+#
+FROM ppc64le/golang:1.12.6-alpine3.9
+MAINTAINER David Wilder <wilder@ibm.com>
 
 # Enable non-native builds of this image on an amd64 hosts.
 # This must be the first RUN command in this file!
@@ -29,7 +66,7 @@ COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 # Install util-linux for column command (used for output formatting).
 # Install grep and sed for use in some Makefiles (e.g. pulling versions out of glide.yaml)
 # Install shadow for useradd (it allows to use big UID)
-RUN apk update && apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed shadow
+RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed shadow
 RUN apk upgrade --no-cache
 
 # Disable ssh host key checking
@@ -43,42 +80,16 @@ ENV CGO_ENABLED=0
 # marked stale, causing full rebuilds every time.
 RUN go install -v std
 
-# Install glide
-RUN go get github.com/Masterminds/glide
 ENV GLIDE_HOME /home/user/.glide
 
-# Install dep
-RUN go get github.com/golang/dep/cmd/dep
-
-# Install ginkgo CLI tool for running tests
-RUN go get github.com/onsi/ginkgo/ginkgo
-
-# Install linting tools.
-RUN go get -u gopkg.in/alecthomas/gometalinter.v2
-RUN ln -s `which gometalinter.v2` /usr/local/bin/gometalinter
-RUN gometalinter --install
-
-# Install license checking tool.
-RUN go get github.com/pmezard/licenses
-
-# Install tool to merge coverage reports.
-RUN go get github.com/wadey/gocovmerge
-
-# Install CLI tool for working with yaml files
-RUN go get github.com/mikefarah/yaml
+# Install prebuilt tools and deps.
+COPY --from=build_tools /go/bin/* /go/bin/
 
 # Delete all the Go sources that were downloaded, we only rely on the binaries
 RUN rm -rf /go/src/*
 
-# Install vgo (should be removed once we take Go 1.11)
-RUN go get -u golang.org/x/vgo
-
 # Ensure that everything under the GOPATH is writable by everyone
 RUN chmod -R 777 $GOPATH
-
-RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-ppc64le > manifest-tool && \
-    chmod +x manifest-tool && \
-    mv manifest-tool /usr/bin/
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -34,9 +34,6 @@ RUN GO111MODULE=on go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-amd64 > manifest-tool && \
     chmod +x manifest-tool
 
-# Install vgo (should be removed once we take Go 1.11)
-RUN go get -u golang.org/x/vgo
-
 #
 # The main image.
 #

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,3 +1,6 @@
+#
+# Build qemu binaries.
+#
 FROM alpine:3.8 as qemu
 
 ARG QEMU_VERSION=2.9.1-1
@@ -9,10 +12,39 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM s390x/golang:1.11.9-alpine3.8
-MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
+#
+# Build tools and deps.
+#
+FROM s390x/golang:1.11.9-alpine3.8 as build_tools
+RUN apk add --no-cache git curl
 
 ARG MANIFEST_TOOL_VERSION=v0.7.0
+
+# Disable cgo so that binaries we build will be fully static.
+ENV CGO_ENABLED=0
+
+RUN go get github.com/Masterminds/glide
+RUN go get github.com/golang/dep/cmd/dep
+RUN go get github.com/onsi/ginkgo/ginkgo
+RUN go get github.com/pmezard/licenses
+RUN go get github.com/wadey/gocovmerge
+RUN go get -u github.com/jstemmer/go-junit-report
+
+RUN go get -u gopkg.in/alecthomas/gometalinter.v2
+RUN ln -s `which gometalinter.v2` /go/bin/gometalinter
+RUN gometalinter --install
+
+RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-amd64 > manifest-tool && \
+    chmod +x manifest-tool
+
+# Install vgo (should be removed once we take Go 1.11)
+RUN go get -u golang.org/x/vgo
+
+#
+# The main image.
+#
+FROM s390x/golang:1.11.9-alpine3.8
+MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
 
 # Enable non-native builds of this image on an amd64 hosts.
 # This must be the first RUN command in this file!
@@ -43,42 +75,16 @@ ENV CGO_ENABLED=0
 # marked stale, causing full rebuilds every time.
 RUN go install -v std
 
-# Install glide
-RUN go get github.com/Masterminds/glide
 ENV GLIDE_HOME /home/user/.glide
 
-# Install dep
-RUN go get github.com/golang/dep/cmd/dep
-
-# Install ginkgo CLI tool for running tests
-RUN go get github.com/onsi/ginkgo/ginkgo
-
-# Install linting tools.
-RUN go get -u gopkg.in/alecthomas/gometalinter.v2
-RUN ln -s `which gometalinter.v2` /usr/local/bin/gometalinter
-RUN gometalinter --install
-
-# Install license checking tool.
-RUN go get github.com/pmezard/licenses
-
-# Install tool to merge coverage reports.
-RUN go get github.com/wadey/gocovmerge
-
-# Install CLI tool for working with yaml files
-RUN go get github.com/mikefarah/yaml
+# Install prebuilt tools and deps.
+COPY --from=build_tools /go/bin/* /go/bin/
 
 # Delete all the Go sources that were downloaded, we only rely on the binaries
 RUN rm -rf /go/src/*
 
-# Install vgo (should be removed once we take Go 1.11)
-RUN go get -u golang.org/x/vgo
-
 # Ensure that everything under the GOPATH is writable by everyone
 RUN chmod -R 777 $GOPATH
-
-RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-s390x > manifest-tool && \
-    chmod +x manifest-tool && \
-    mv manifest-tool /usr/bin/
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -29,10 +29,7 @@ RUN go get github.com/onsi/ginkgo/ginkgo
 RUN go get github.com/pmezard/licenses
 RUN go get github.com/wadey/gocovmerge
 RUN go get -u github.com/jstemmer/go-junit-report
-
-RUN go get -u gopkg.in/alecthomas/gometalinter.v2
-RUN ln -s `which gometalinter.v2` /go/bin/gometalinter
-RUN gometalinter --install
+RUN GO111MODULE=on go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.1
 
 RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-amd64 > manifest-tool && \
     chmod +x manifest-tool


### PR DESCRIPTION
See https://github.com/alecthomas/gometalinter/issues/590

I did a quick search and we are specifying the tag for usages of `calico/go-build` in our Makefiles so this shouldn't break existing CI builds.