### PR TITLE
restore docker binary

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -24,7 +24,7 @@ ARG MANIFEST_TOOL_VERSION=v0.7.0
 # Install libc6-compat for fossa client
 # Install shadow for useradd (it allows to use big UID)
 RUN apk update && apk upgrade --available
-RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed libc6-compat shadow
+RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux docker tini file grep sed libc6-compat shadow
 RUN apk upgrade --no-cache
 
 # Install fossa for foss license checks

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -29,7 +29,7 @@ COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 # Install util-linux for column command (used for output formatting).
 # Install grep and sed for use in some Makefiles (e.g. pulling versions out of glide.yaml)
 # Install shadow for useradd (it allows to use big UID)
-RUN apk update && apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed shadow
+RUN apk update && apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux docker tini file grep sed shadow
 RUN apk upgrade --no-cache
 
 # Disable ssh host key checking

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -29,7 +29,7 @@ COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 # Install util-linux for column command (used for output formatting).
 # Install grep and sed for use in some Makefiles (e.g. pulling versions out of glide.yaml)
 # Install shadow for useradd (it allows to use big UID)
-RUN apk update && apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed shadow
+RUN apk update && apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux docker tini file grep sed shadow
 RUN apk upgrade --no-cache
 
 # Disable ssh host key checking

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -29,7 +29,7 @@ COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 # Install util-linux for column command (used for output formatting).
 # Install grep and sed for use in some Makefiles (e.g. pulling versions out of glide.yaml)
 # Install shadow for useradd (it allows to use big UID)
-RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed shadow
+RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux docker tini file grep sed shadow
 RUN apk upgrade --no-cache
 
 # Disable ssh host key checking


### PR DESCRIPTION
Un-do: https://github.com/projectcalico/go-build/commit/4e89359bc716d3efff7efe36c4b57b4c52afa7bf#diff-c8b09f88c044c3dec6a30981db2282e9 since `docker` binary is used in a tigera/private repo: `calicoq`.