### PR TITLE
Update to golangcli-lint 1.20.0, because...

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -55,7 +55,7 @@ RUN go get github.com/onsi/ginkgo/ginkgo
 
 # Install linting tools.
 RUN go get golang.org/x/tools/cmd/goimports
-RUN wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.19.1
+RUN wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.20.0
 RUN golangci-lint --version
 
 # Install license checking tool.

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -54,7 +54,7 @@ RUN go get github.com/golang/dep/cmd/dep
 RUN go get github.com/onsi/ginkgo/ginkgo
 
 # Install linting tools.
-RUN wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.19.1
+RUN wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.20.0
 RUN golangci-lint --version
 
 # Install license checking tool.


### PR DESCRIPTION
1. Release notes include `95ec0cf dramatically reduce memory
usage (#758)`

2. Hoping it will fix this false positive:

     pkg/log/log.go:20:5: var `tag` is unused (unused)
     var tag string
         ^