### PR TITLE
go mod tidy after updating pins

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -269,6 +269,9 @@ replace-felix-pin:
 replace-cni-pin:
 	$(call update_replace_pin,github.com/projectcalico/cni-plugin,$(CNI_REPO),$(CNI_BRANCH))
 
+go-mod-tidy:
+	$(DOCKER_GO_BUILD) go mod tidy
+
 git-status:
 	git status --porcelain
 
@@ -285,7 +288,7 @@ git-push:
 	git push
 
 ## Update dependency pins to their latest changeset, committing and pushing it.
-commit-pin-updates: update-pins build git-status git-config git-commit ci git-push
+commit-pin-updates: update-pins go-mod-tidy build git-status git-config git-commit ci git-push
 
 ###############################################################################
 # Static checks


### PR DESCRIPTION
This fixes an issue where after `update-pins` is called, `build` may also need to update the `go.sum`. But, when this target is run in Semaphore, we also run this with the GO_FLAG `-mod=readonly` and so `build` fails. E.g.

```
Semaphore (18 min left): ~/node $ make build
"Build dependency versions"
BIRD_VERSION          = v0.3.3-145-g049d13dc
"Test dependency versions"
CNI_VER               = master
"Calico git version"
GIT_VERSION           = v3.11.0-0.dev-78-gac80c2a-dirty
mkdir -p .go-pkg-cache bin /home/runner/go/pkg/mod && docker run --rm --net=host -v /tmp/ssh-gGlj3DANm4xb/agent.2034:/ssh-agent --env SSH_AUTH_SOCK=/ssh-agent -e GO111MODULE=on -v /home/runner/go/pkg/mod:/go/pkg/mod:rw -e LOCAL_USER_ID=1003 -e GOCACHE=/go-cache -e GOARCH=amd64 -e GOPATH=/go -e OS=linux -e GOOS=linux -e GOFLAGS="-mod=readonly" -v /home/runner/node:/go/src/github.com/projectcalico/node:rw -v /home/runner/node/.go-pkg-cache:/go-cache:rw -w /go/src/github.com/projectcalico/node calico/go-build:v0.28 go build -v -o dist/bin//calico-node-amd64  -ldflags " -X github.com/projectcalico/node/pkg/startup.VERSION=v3.11.0-0.dev-78-gac80c2a-dirty -X github.com/projectcalico/node/buildinfo.GitVersion=v3.11.0-0.dev-78-gac80c2a-dirty -X github.com/projectcalico/node/buildinfo.BuildDate=2019-12-16T22:35:09+0000 -X github.com/projectcalico/node/buildinfo.GitRevision=ac80c2a019c87d957f8850ab221f5e732602b4ef" ./cmd/calico-node/main.go
Starting with UID : 1003
go: updates to go.sum needed, disabled by -mod=readonly
Makefile:124: recipe for target 'dist/bin//calico-node-amd64' failed
make: *** [dist/bin//calico-node-amd64] Error 1
```

Putting in a `go mod tidy` should fix this.