### PR TITLE
Don't set -mod=readonly in CI for more make targets

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -87,14 +87,28 @@ PUSH_NONMANIFEST_IMAGES=$(filter-out $(PUSH_MANIFEST_IMAGES),$(PUSH_IMAGES))
 # location of docker credentials to push manifests
 DOCKER_CONFIG ?= $(HOME)/.docker/config.json
 
-# If a repository still relies on vendoring, it must set GOMOD_VENDOR to "true". If that's not the
-# case and we're running in CI, set -mod=readonly to prevent builds from being flagged as dirty due to
-# updates in go.mod or go.sum... except for local builds, which _require_ a change to go.mod.
+# If a repository still relies on vendoring, it must set GOMOD_VENDOR to "true".
+# If that's not the case and we're running in CI, set -mod=readonly to prevent builds
+# from being flagged as dirty due to updates in go.mod or go.sum _except_ for:
+# - for local builds, which _require_ a change to go.mod.
+# - the targets 'commit-pin-updates' and 'golangci-lint' which require
+#   updating go.mod and/or go.sum
+SKIP_GOMOD_READONLY_FLAG =
+ifeq ($(MAKECMDGOALS),commit-pin-updates)
+	SKIP_GOMOD_READONLY_FLAG = yes
+endif
+ifeq ($(MAKECMDGOALS),golangci-lint)
+	SKIP_GOMOD_READONLY_FLAG = yes
+endif
+ifeq ($(LOCAL_BUILD),true)
+	SKIP_GOMOD_READONLY_FLAG = yes
+endif
+
 ifeq ($(GOMOD_VENDOR),true)
 	GOFLAGS?="-mod=vendor"
 else
 ifeq ($(CI),true)
-ifneq ($(LOCAL_BUILD),true)
+ifndef SKIP_GOMOD_READONLY_FLAG
 	GOFLAGS?="-mod=readonly"
 endif
 endif


### PR DESCRIPTION
We not only need to skip setting -mod=readonly in local builds but we also need to skip it for the commit-pin-updates target.

Once this is merged I'll release 0.31 and rev calico/node.