### PR TITLE
Add CGO support

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -50,6 +50,22 @@ RUN chmod +x /usr/local/bin/fossa
 RUN echo 'Host *' >> /etc/ssh/ssh_config \
   && echo '    StrictHostKeyChecking no' >> /etc/ssh/ssh_config
 
+# We want to be able to do both cgo and non-cgo builds.  That's awkward because toggling cgo
+# results in parts of the stdlib getting rebuilt (which fails due tot he container's read-only
+# filesystem).  As a workaround: take a copy of the go root for cgo builds and have the
+# entrypoint script swap it into the path if it detects CGO_ENABLED=1.
+ENV GOROOT=/usr/local/go
+ENV GOCGO=$GOROOT/../go-cgo
+
+RUN cp -ra $GOROOT $GOCGO
+
+# Disable cgo by default so that binaries we build will be fully static by default.
+ENV CGO_ENABLED=0
+
+# Recompile the standard library with cgo disabled.  This avoids issues with read-only file system
+# and primes the cache.
+RUN go install -v std
+
 # Install glide
 RUN go get github.com/Masterminds/glide
 ENV GLIDE_HOME /home/user/.glide

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -55,49 +55,30 @@ RUN echo 'Host *' >> /etc/ssh/ssh_config \
 # filesystem).  As a workaround: take a copy of the go root for cgo builds and have the
 # entrypoint script swap it into the path if it detects CGO_ENABLED=1.
 ENV GOROOT=/usr/local/go
-ENV GOCGO=$GOROOT/../go-cgo
-
-RUN cp -ra $GOROOT $GOCGO
+ENV GOCGO=/usr/local/go-cgo
 
 # Disable cgo by default so that binaries we build will be fully static by default.
 ENV CGO_ENABLED=0
 
-# Recompile the standard library with cgo disabled.  This avoids issues with read-only file system
-# and primes the cache.
-RUN go install -v std
+RUN cp -ra $GOROOT $GOCGO && \
+  go install -v std && \
+  rm -rf /go/src/* /root/.cache
 
-# Install glide
-RUN go get github.com/Masterminds/glide
+# Install go programs that we rely on
 ENV GLIDE_HOME /home/user/.glide
-
-# Install dep
-RUN go get github.com/golang/dep/cmd/dep
-
-# Install ginkgo CLI tool for running tests
-RUN go get github.com/onsi/ginkgo/ginkgo
-
-# Install linting tools.
-RUN go get golang.org/x/tools/cmd/goimports
-RUN wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.20.0
-RUN golangci-lint --version
-
-# Install license checking tool.
-RUN go get github.com/pmezard/licenses
-
-# Install tool to merge coverage reports.
-RUN go get github.com/wadey/gocovmerge
-
-# Install CLI tool for working with yaml files
-RUN go get github.com/mikefarah/yaml
-
-# Install vgo (should be removed once we take Go 1.11)
-RUN go get -u golang.org/x/vgo
-
-# Install tool to convert go-test output to junit
-RUN go get -u github.com/jstemmer/go-junit-report
-
-# Install tool to generate enum String() methods.
-RUN go get -u golang.org/x/tools/cmd/stringer
+RUN go get github.com/Masterminds/glide && \
+  go get github.com/golang/dep/cmd/dep && \
+  go get github.com/onsi/ginkgo/ginkgo && \
+  go get golang.org/x/tools/cmd/goimports && \
+  wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.20.0 && \
+  golangci-lint --version && \
+  go get github.com/pmezard/licenses && \
+  go get github.com/wadey/gocovmerge && \
+  go get github.com/mikefarah/yaml && \
+  go get -u golang.org/x/vgo && \
+  go get -u github.com/jstemmer/go-junit-report && \
+  go get -u golang.org/x/tools/cmd/stringer && \
+  rm -rf /go/src/* /root/.cache
 
 # Enable non-native runs on amd64 architecture hosts
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
@@ -106,9 +87,6 @@ RUN chmod +x /usr/bin/qemu-*
 # When running cross built binaries run-times will be auto-installed,
 # ensure the install directory is writable by everyone.
 RUN for arch in ${CROSS_ARCHS}; do mkdir -m +w -p /usr/local/go/pkg/linux_${arch}; GOARCH=${arch} go install -v std; done
-
-# Delete all the Go sources that were downloaded, we only rely on the binaries
-RUN rm -rf /go/src/*
 
 # Ensure that everything under the GOPATH is writable by everyone
 RUN chmod -R 777 $GOPATH

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -33,6 +33,8 @@ RUN apt-get -y update &&  \
         ca-certificates gcc libc-dev bsdmainutils strace && \
     rm -rf /var/lib/apt/lists/*
 
+# su-exec is used by the entrypoint script to execute the user's command with the right UID/GID.
+# (sudo doesn't work easily in a container.)  The version was current master at the time of writing.
 ARG SU_EXEC_VER=212b75144bbc06722fbd7661f651390dc47a43d1
 RUN  set -ex; \
      curl -o /sbin/su-exec.c https://raw.githubusercontent.com/ncopa/su-exec/${SU_EXEC_VER}/su-exec.c; \
@@ -51,7 +53,7 @@ RUN echo 'Host *' >> /etc/ssh/ssh_config \
   && echo '    StrictHostKeyChecking no' >> /etc/ssh/ssh_config
 
 # We want to be able to do both cgo and non-cgo builds.  That's awkward because toggling cgo
-# results in parts of the stdlib getting rebuilt (which fails due tot he container's read-only
+# results in parts of the stdlib getting rebuilt (which fails due to the container's read-only
 # filesystem).  As a workaround: take a copy of the go root for cgo builds and have the
 # entrypoint script swap it into the path if it detects CGO_ENABLED=1.
 ENV GOROOT=/usr/local/go
@@ -60,7 +62,7 @@ ENV GOCGO=/usr/local/go-cgo
 # Disable cgo by default so that binaries we build will be fully static by default.
 ENV CGO_ENABLED=0
 
-RUN cp -ra $GOROOT $GOCGO && \
+RUN cp -a $GOROOT $GOCGO && \
   go install -v std && \
   rm -rf /go/src/* /root/.cache
 

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,5 +1,7 @@
-FROM amd64/golang:1.12.14-alpine3.10
-MAINTAINER Tom Denham <tom@projectcalico.org>
+FROM calico/bpftool:v5.3-amd64 as bpftool
+
+FROM amd64/golang:1.13.7-buster
+MAINTAINER Shaun Crampton <shaun@projectcalico.org>
 
 ARG QEMU_VERSION=2.9.1-1
 
@@ -21,11 +23,23 @@ ARG MANIFEST_TOOL_VERSION=v0.7.0
 # Install make for building things
 # Install util-linux for column command (used for output formatting).
 # Install grep and sed for use in some Makefiles (e.g. pulling versions out of glide.yaml)
-# Install libc6-compat for fossa client
-# Install shadow for useradd (it allows to use big UID)
-RUN apk update && apk upgrade --available
-RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed libc6-compat shadow
-RUN apk upgrade --no-cache
+# Install gcc for cgo.
+# Install clang for building BPF binaries.
+RUN apt-get -y update &&  \
+    apt-get -y upgrade && \
+    apt-get install --no-install-recommends -y \
+        curl bash git openssh-client mercurial make wget util-linux file grep sed \
+        llvm clang libbpf-dev binutils file iproute2 \
+        ca-certificates gcc libc-dev bsdmainutils strace && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG SU_EXEC_VER=212b75144bbc06722fbd7661f651390dc47a43d1
+RUN  set -ex; \
+     curl -o /sbin/su-exec.c https://raw.githubusercontent.com/ncopa/su-exec/${SU_EXEC_VER}/su-exec.c; \
+     gcc -Wall /sbin/su-exec.c -o/sbin/su-exec; \
+     chown root:root /sbin/su-exec; \
+     chmod 0755 /sbin/su-exec; \
+     rm /sbin/su-exec.c
 
 # Install fossa for foss license checks
 ARG FOSSA_VER=1.0.1
@@ -35,13 +49,6 @@ RUN chmod +x /usr/local/bin/fossa
 # Disable ssh host key checking
 RUN echo 'Host *' >> /etc/ssh/ssh_config \
   && echo '    StrictHostKeyChecking no' >> /etc/ssh/ssh_config
-
-# Disable cgo so that binaries we build will be fully static.
-ENV CGO_ENABLED=0
-
-# Recompile the standard library with cgo disabled.  This prevents the standard library from being
-# marked stale, causing full rebuilds every time.
-RUN go install -v std
 
 # Install glide
 RUN go get github.com/Masterminds/glide
@@ -73,6 +80,9 @@ RUN go get -u golang.org/x/vgo
 # Install tool to convert go-test output to junit
 RUN go get -u github.com/jstemmer/go-junit-report
 
+# Install tool to generate enum String() methods.
+RUN go get -u golang.org/x/tools/cmd/stringer
+
 # Enable non-native runs on amd64 architecture hosts
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
@@ -91,5 +101,8 @@ RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFE
     chmod +x manifest-tool && \
     mv manifest-tool /usr/bin/
 
+# Add bpftool for Felix UT/FV.
+COPY --from=bpftool /bpftool /usr/bin
+
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm64v8/golang:1.12.14-alpine3.10
+FROM arm64v8/golang:1.13.7-alpine3.10
 MAINTAINER Trevor Tao <trevor.tao@arm.com>
 
 ARG MANIFEST_TOOL_VERSION=v0.7.0

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM ppc64le/golang:1.12.14-alpine3.10
+FROM ppc64le/golang:1.13.7-alpine3.10
 MAINTAINER David Wilder <wilder@ibm.com>
 
 ARG MANIFEST_TOOL_VERSION=v0.7.0

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM s390x/golang:1.11.9-alpine3.8
+FROM s390x/golang:1.13.7-alpine3.8
 MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
 
 ARG MANIFEST_TOOL_VERSION=v0.7.0

--- a/Makefile.common
+++ b/Makefile.common
@@ -184,6 +184,7 @@ endif
 DOCKER_RUN := mkdir -p .go-pkg-cache bin $(GOMOD_CACHE) && \
 	docker run --rm \
 		--net=host \
+		--init \
 		$(EXTRA_DOCKER_ARGS) \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
 		-e GOCACHE=/go-cache \
@@ -199,6 +200,7 @@ DOCKER_RUN := mkdir -p .go-pkg-cache bin $(GOMOD_CACHE) && \
 DOCKER_RUN_RO := mkdir -p .go-pkg-cache bin $(GOMOD_CACHE) && \
 	docker run --rm \
 		--net=host \
+		--init \
 		$(EXTRA_DOCKER_ARGS) \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
 		-e GOCACHE=/go-cache \

--- a/Makefile.common
+++ b/Makefile.common
@@ -316,7 +316,7 @@ commit-pin-updates: update-pins build git-status git-config git-commit ci git-pu
 static-checks: $(LOCAL_CHECKS)
 	$(MAKE) golangci-lint
 
-LINT_ARGS ?= --max-issues-per-linter 0 --max-same-issues 0 --deadline 5m
+LINT_ARGS ?= --max-issues-per-linter 0 --max-same-issues 0 --timeout 5m
 
 .PHONY: golangci-lint
 golangci-lint: $(GENERATED_FILES)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,10 @@
 
 USER_ID=${LOCAL_USER_ID:-9001}
 
+if [ "${RUN_AS_ROOT}" = "true" ]; then
+  exec "$@"
+fi
+
 echo "Starting with UID : $USER_ID" 1>&2
 # Do not create mail box.
 /bin/sed -i 's/^CREATE_MAIL_SPOOL=yes/CREATE_MAIL_SPOOL=no/' /etc/default/useradd

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,12 @@ if [ -n "$EXTRA_GROUP_ID"  ]; then
     echo "Adding user to existing group instead" 1>&2
     addgroup user `getent group $EXTRA_GROUP_ID | cut -d: -f1`
   fi
-fi  
+fi
+
+if [ $CGO_ENABLED = "1" ]; then
+  echo "CGO enabled, switching GOROOT to $GOCGO."
+  export GOROOT=$GOCGO
+  export PATH=$GOCGO/bin:$PATH
+fi
 
 exec /sbin/su-exec user "$@"


### PR DESCRIPTION
Some upcoming felix features need CGO support. This PR 

- Reinstate Go 1.13 now the crash is fixed.
- Rebases onto Debian so we get a libc that matches our release images.
- Adds gcc for CGO support.
- Makes a second copy of the GOROOT with CGO enabled (since lots of our builds require CGO disabled and it doesn't seem to be possible to share the same go install between CGO and non-CGO without rebuilding the standard lib)
- Enhances the entrypoint script to choose between the two GOROOTs.
- Removes tini since (1) it's hard to get it running on debian and (2) it's now built into docker via the `--init` flag, which I've added to the common makefile.
- Add clang so we can use go-build for BPF builds (previously we were relying on a container built locally in the felix repo)
- Add support for running as root to allow Felix's BPF FV tests to be run in this container instead of rebuilding the felix container for that purpose.
- To slightly offset the new bloat, reduce the number of layers and clean up source files and caches inside the relevant layers (saves 200+MB).