### PR TITLE
Build for 32-bit arm v7

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -8,8 +8,8 @@ ARG QEMU_VERSION=4.2.0-6
 # we need these two distinct lists. The first one is the names used by the qemu distributions
 # these second is the names used by golang see https://github.com/golang/go/blob/master/src/go/build/syslist.go
 # the primary difference as of this writing is that qemu uses aarch64 and golang uses arm64
-ARG QEMU_ARCHS="aarch64 ppc64le s390x"
-ARG CROSS_ARCHS="arm64 ppc64le s390x"
+ARG QEMU_ARCHS="arm aarch64 ppc64le s390x"
+ARG CROSS_ARCHS="arm arm64 ppc64le s390x"
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2
 

--- a/Dockerfile.arm.v7
+++ b/Dockerfile.arm.v7
@@ -1,0 +1,84 @@
+FROM alpine:3.10 as qemu
+
+ARG QEMU_VERSION=2.9.1-1
+ARG QEMU_ARCHS="arm"
+
+RUN apk --update add curl
+
+# Enable non-native runs on amd64 architecture hosts
+RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
+RUN chmod +x /usr/bin/qemu-*
+
+FROM arm32v7/golang:1.13.7-alpine3.10
+MAINTAINER Josua Mayer <josua@solid-run.com>
+
+ARG MANIFEST_TOOL_VERSION=v1.0.2
+
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
+COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
+
+# Install su-exec for use in the entrypoint.sh (so processes run as the right user)
+# Install bash for the entry script (and because it's generally useful)
+# Install curl to download glide
+# Install git for fetching Go dependencies
+# Install ssh for fetching Go dependencies
+# Install mercurial for fetching go dependencies
+# Install wget since it's useful for fetching
+# Install make for building things
+# Install util-linux for column command (used for output formatting).
+# Install grep and sed for use in some Makefiles (e.g. pulling versions out of glide.yaml)
+# Install shadow for useradd (it allows to use big UID)
+RUN apk update && apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed shadow
+RUN apk upgrade --no-cache
+
+# Disable ssh host key checking
+RUN echo 'Host *' >> /etc/ssh/ssh_config \
+  && echo '    StrictHostKeyChecking no' >> /etc/ssh/ssh_config
+
+# Disable cgo so that binaries we build will be fully static.
+ENV CGO_ENABLED=0
+
+# Recompile the standard library with cgo disabled.  This prevents the standard library from being
+# marked stale, causing full rebuilds every time.
+RUN go install -v std
+
+# Install glide
+RUN go get github.com/Masterminds/glide
+ENV GLIDE_HOME /home/user/.glide
+
+# Install dep
+RUN go get github.com/golang/dep/cmd/dep
+
+# Install ginkgo CLI tool for running tests
+RUN go get github.com/onsi/ginkgo/ginkgo
+
+# Install linting tools.
+RUN go get -u gopkg.in/alecthomas/gometalinter.v2
+RUN ln -s `which gometalinter.v2` /usr/local/bin/gometalinter
+RUN gometalinter --install
+
+# Install license checking tool.
+RUN go get github.com/pmezard/licenses
+
+# Install tool to merge coverage reports.
+RUN go get github.com/wadey/gocovmerge
+
+# Install CLI tool for working with yaml files
+RUN go get github.com/mikefarah/yaml
+
+# Delete all the Go sources that were downloaded, we only rely on the binaries
+RUN rm -rf /go/src/*
+
+# Install vgo (should be removed once we take Go 1.11)
+RUN go get -u golang.org/x/vgo
+
+# Ensure that everything under the GOPATH is writable by everyone
+RUN chmod -R 777 $GOPATH
+
+RUN curl -sSL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-armv7 > manifest-tool && \
+    chmod +x manifest-tool && \
+    mv manifest-tool /usr/bin/
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: image-all
 # The target architecture is select by setting the ARCH variable.
 # When ARCH is undefined it is set to the detected host architecture.
 # When ARCH differs from the host architecture a crossbuild will be performed.
-ARCHES = amd64 arm64 ppc64le s390x
+ARCHES = amd64 armv7l arm64 ppc64le s390x
 
 # BUILDARCH is the host architecture
 # ARCH is the target architecture
@@ -16,6 +16,9 @@ ARCHES = amd64 arm64 ppc64le s390x
 BUILDARCH ?= $(shell uname -m)
 
 # canonicalized names for host architecture
+ifeq ($(BUILDARCH),armv7l)
+        BUILDARCH=arm/v7
+endif
 ifeq ($(BUILDARCH),aarch64)
         BUILDARCH=arm64
 endif
@@ -27,6 +30,9 @@ endif
 ARCH ?= $(BUILDARCH)
 
 # canonicalized names for target architecture
+ifeq ($(ARCH),armv7l)
+        override ARCH=arm/v7
+endif
 ifeq ($(ARCH),aarch64)
         override ARCH=arm64
 endif


### PR DESCRIPTION
This PR introduces the v7 variant of the arm architecture as build target.

Build-tested natively on debian 10 - armhf, cross-compiled on amd64, pushed to https://quay.io/repository/josua-sr/calico_go-build?tab=tags for verifying the manifest.

The second commit has some potentially relevant changes - I tried to make it in a way that no existing names or image tags change - and only added docker platform `arm/v7` with the image tag suffix `-armv7`.