### PR TITLE
Update user/group add command per Debian tools.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,11 +25,11 @@ export HOME=/home/user
 if [ -n "$EXTRA_GROUP_ID"  ]; then
   echo "Adding user to additional GID : $EXTRA_GROUP_ID" 1>&2
   # Adding the group can fail if it already exists.
-  if addgroup -g $EXTRA_GROUP_ID group; then
-    addgroup user group
+  if addgroup --gid $EXTRA_GROUP_ID group; then
+    adduser user group
   else
     echo "Adding user to existing group instead" 1>&2
-    addgroup user `getent group $EXTRA_GROUP_ID | cut -d: -f1`
+    adduser user `getent group $EXTRA_GROUP_ID | cut -d: -f1`
   fi
 fi
 


### PR DESCRIPTION
## Description

After moving to 1.13 Debian image, `addgroup` fails with ambiguous option and eventually not adding user to the extra-group-id.

This PR proposes to fix `addgroup` usage and replacing `addgroup` by `adduser` to support adding `user` to an existing group.

```
adduser USER GROUP
   Add an existing user to an existing group
```