### PR TITLE
Revert "Avoid updating global git config for pin update commit"

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -292,17 +292,20 @@ replace-cni-pin:
 git-status:
 	git status --porcelain
 
-AUTHOR  = "Semaphore Automatic Update"
-COMMENT = "Semaphore Automatic Update"
-EMAIL   = "marvin@projectcalico.io"
+git-config:
+ifdef CONFIRM
+	git config --global user.name "Semaphore Automatic Update"
+	git config --global user.email "marvin@projectcalico.io"
+endif
+
 git-commit:
-	git diff --quiet HEAD || git commit -m $(COMMENT) -c "user.name=$(AUTHOR)" -c "user.email=$(EMAIL)" go.mod go.sum
+	git diff --quiet HEAD || git commit -m "Semaphore Automatic Update" go.mod go.sum
 
 git-push:
 	git push
 
 ## Update dependency pins to their latest changeset, committing and pushing it.
-commit-pin-updates: update-pins build git-status git-commit ci git-push
+commit-pin-updates: update-pins build git-status git-config git-commit ci git-push
 
 ###############################################################################
 # Static checks


### PR DESCRIPTION
This reverts commit e4be75a7cfc67755a7f3b0d32236e0464193146e.