### PR TITLE
Fix s390x crossbuild, testcompile and Dockerfile.s390x

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -3,7 +3,7 @@ FROM calico/bpftool:v5.3-amd64 as bpftool
 FROM amd64/golang:1.13.7-buster
 MAINTAINER Shaun Crampton <shaun@projectcalico.org>
 
-ARG QEMU_VERSION=2.9.1-1
+ARG QEMU_VERSION=4.2.0-6
 
 # we need these two distinct lists. The first one is the names used by the qemu distributions
 # these second is the names used by golang see https://github.com/golang/go/blob/master/src/go/build/syslist.go

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,6 +1,6 @@
 FROM alpine:3.10 as qemu
 
-ARG QEMU_VERSION=2.9.1-1
+ARG QEMU_VERSION=4.2.0-6
 ARG QEMU_ARCHS="s390x"
 
 RUN apk --update add curl
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM s390x/golang:1.13.7-alpine3.8
+FROM s390x/golang:1.13.7-alpine3.10
 MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
 
 ARG MANIFEST_TOOL_VERSION=v0.7.0
@@ -29,7 +29,7 @@ COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 # Install util-linux for column command (used for output formatting).
 # Install grep and sed for use in some Makefiles (e.g. pulling versions out of glide.yaml)
 # Install shadow for useradd (it allows to use big UID)
-RUN apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed shadow
+RUN apk update && apk add --no-cache su-exec curl bash git openssh mercurial make wget util-linux tini file grep sed shadow
 RUN apk upgrade --no-cache
 
 # Disable ssh host key checking

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: image-all
 # The target architecture is select by setting the ARCH variable.
 # When ARCH is undefined it is set to the detected host architecture.
 # When ARCH differs from the host architecture a crossbuild will be performed.
-ARCHES = amd64 arm64 ppc64le
+ARCHES = amd64 arm64 ppc64le s390x
 
 # BUILDARCH is the host architecture
 # ARCH is the target architecture


### PR DESCRIPTION
Signed-off-by: Nirman Narang <narang@us.ibm.com>

Fixed s390x cross-build using the latest qemu v4.2.0-6.
Fixed Dockerfile.s390x with golang:1.13.7-alpine3.10 as the same is not available for alpine3.8.
Added s390x to ARCHS in Makefile.