### PR TITLE
Use EXTRA_COMMIT_PATTERNS env for git-commit target

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -299,7 +299,7 @@ ifdef CONFIRM
 endif
 
 git-commit:
-	git diff --quiet HEAD || git commit -m "Semaphore Automatic Update" go.mod go.sum
+	git diff --quiet HEAD || git commit -m "Semaphore Automatic Update" go.mod go.sum $(EXTRA_FILES_TO_COMMIT)
 
 git-push:
 	git push


### PR DESCRIPTION
This will allow projects to specify extra files to commit when doing auto pin updates, i.e. generated files