### PR TITLE
Switch to semaphore v2

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,74 @@
+version: v1.0
+name: go-build
+agent:
+  machine:
+    type: e1-standard-4
+    os_image: ubuntu1804
+execution_time_limit:
+  minutes: 120
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+      # Semaphore is doing shallow clone on a commit without tags.
+      # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always) @ Makefile.common
+      - git fetch --unshallow
+
+blocks:
+
+# Run the full set of tests. Each job can potentially be run in parallel,
+# provided Semaphore has enough boxes available.
+- name: "Tests"
+  dependencies: []
+  run:
+    when: "change_in('/Makefile.common') or change_in('/.semaphore/')"
+  task:
+    jobs:
+    - name: "Build downstream projects with our Makefile.common"
+      commands:
+      - git clone git@github.com:projectcalico/$REPO.git $REPO
+      - cd $REPO
+      - make Makefile.common
+      - cp ../Makefile.common ./
+      - make ut
+      matrix:
+      - env_var: REPO
+        values: ["felix", "calicoctl", "libcalico-go"]
+
+- name: "Build images"
+  dependencies: []
+  task:
+    secrets:
+    - name: quay-robot-calico+semaphoreci
+    - name: docker
+    jobs:
+    - name: Build and push image
+      commands:
+      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
+      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
+      - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
+      - export VERSION=$BRANCH_NAME
+      - make image ARCH=$ARCH
+      - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make push ARCH=$ARCH CONFIRM=true; fi
+      matrix:
+      - env_var: ARCH
+        values: ["amd64", "arm64", "ppc64le"]
+
+- name: "Push manifest"
+  skip:
+    # Only run on branches, not PRs.
+    when: "branch !~ '.+'"
+  dependencies: ["Build images"]
+  task:
+    secrets:
+    - name: quay-robot-calico+semaphoreci
+    - name: docker
+    jobs:
+    - name: Push multi-arch manifest
+      commands:
+      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
+      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
+      - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
+      - export VERSION=$BRANCH_NAME
+      - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make push-manifest CONFIRM=true; fi
+

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ sub-image-%:
 # Enable binfmt adding support for miscellaneous binary formats.
 .PHONY: register
 register:
-ifeq ($(ARCH),amd64)
+ifeq ($(BUILDARCH),amd64)
 	docker run --rm --privileged multiarch/qemu-user-static:register --reset
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -53,9 +53,12 @@ join_platforms = $(subst $(space),$(comma),$(call prefix_linux,$(strip $1)))
 
 # Check if the docker daemon is running in experimental mode (to get the --squash flag)
 DOCKER_EXPERIMENTAL=$(shell docker version -f '{{ .Server.Experimental }}')
-DOCKER_BUILD_ARGS=
+DOCKER_BUILD_ARGS?=
 ifeq ($(DOCKER_EXPERIMENTAL),true)
-        override DOCKER_BUILD_ARGS=--squash
+DOCKER_BUILD_ARGS+=--squash
+endif
+ifneq ($(ARCH),amd64)
+DOCKER_BUILD_ARGS+=--cpuset-cpus 0
 endif
 
 ###############################################################################
@@ -65,7 +68,7 @@ image: calico/go-build
 calico/go-build: register
 	# Make sure we re-pull the base image to pick up security fixes.
 	# Limit the build to use only one CPU, This helps to work around qemu bugs such as https://bugs.launchpad.net/qemu/+bug/1098729
-	docker build $(DOCKER_BUILD_ARGS) --cpuset-cpus 0 --pull -t $(ARCHIMAGE) -f $(DOCKERFILE) .
+	docker build $(DOCKER_BUILD_ARGS) --pull -t $(ARCHIMAGE) -f $(DOCKERFILE) .
 
 image-all: $(addprefix sub-image-,$(ARCHES))
 sub-image-%:


### PR DESCRIPTION
* Add a pipeline manifest
* Parallelise the build.
* Enable multi-core builds for the AMD64 image.
* Make sure we register qemu if we're building on AMD64 (rather than building _for_ AMD64).