### PR TITLE
Add mockery to build image / add mockery utils

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -52,6 +52,10 @@ ARG FOSSA_VER=1.0.1
 RUN curl -L https://github.com/fossas/fossa-cli/releases/download/v${FOSSA_VER}/fossa-cli_${FOSSA_VER}_linux_amd64.tar.gz | tar zxvf - -C /usr/local/bin --extract fossa
 RUN chmod +x /usr/local/bin/fossa
 
+ARG MOCKERY_VER=2.3.0
+RUN curl -L https://github.com/vektra/mockery/releases/download/v${MOCKERY_VER}/mockery_${MOCKERY_VER}_Linux_x86_64.tar.gz | tar zxvf - -C /usr/local/bin --extract mockery
+RUN chmod +x /usr/local/bin/mockery
+
 # Disable ssh host key checking
 RUN echo 'Host *' >> /etc/ssh/ssh_config \
   && echo '    StrictHostKeyChecking no' >> /etc/ssh/ssh_config

--- a/Makefile.common
+++ b/Makefile.common
@@ -516,6 +516,24 @@ semaphore-run-auto-pin-update-workflows:
 	done
 
 ###############################################################################
+# Mock helpers
+###############################################################################
+# Helper targets for testify mock generation
+
+# Generate testify mocks in the build container.
+gen-mocks:
+	$(DOCKER_RUN) $(CALICO_BUILD) sh -c '$(MAKE) mockery-run'
+
+# Run mockery for each path in MOCKERY_FILE_PATHS. The the generated mocks are
+# created in package and in test files. Look here for more information https://github.com/vektra/mockery
+mockery-run:
+	for FILE_PATH in $(MOCKERY_FILE_PATHS); do\
+		DIR=$$(dirname $$FILE_PATH); \
+		INTERFACE_NAME=$$(basename $$FILE_PATH); \
+		mockery --dir $$DIR --name $$INTERFACE_NAME --inpackage --testonly; \
+	done
+
+###############################################################################
 # Helpers
 ###############################################################################
 ## Help


### PR DESCRIPTION
This commit adds mockery to the build image to help generate testify mocks. There are helper targets that projects can use to make sure that the mocks are regenerated if interfaces change.