### PR TITLE
Automated cherry pick of #122: RUN_AS_ROOT=true if uid is 0

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -156,6 +156,11 @@ DATE:=$(shell date -u +'%FT%T%z')
 LOCAL_USER_ID:=$(shell id -u)
 LOCAL_GROUP_ID:=$(shell id -g)
 
+ifeq ("$(LOCAL_USER_ID)", "0")
+# The build needs to run as root.
+EXTRA_DOCKER_ARGS+=-e RUN_AS_ROOT='true'
+endif
+
 # Allow the ssh auth sock to be mapped into the build container.
 ifdef SSH_AUTH_SOCK
 	EXTRA_DOCKER_ARGS += -v $(SSH_AUTH_SOCK):/ssh-agent --env SSH_AUTH_SOCK=/ssh-agent


### PR DESCRIPTION
Cherry pick of #122 on v0.43.

#122: RUN_AS_ROOT=true if uid is 0