### PR TITLE
Automated cherry pick of #200: add git ssh for golang-ci-lint target

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -439,7 +439,7 @@ LINT_ARGS ?= --max-issues-per-linter 0 --max-same-issues 0 --timeout 5m
 
 .PHONY: golangci-lint
 golangci-lint: $(GENERATED_FILES)
-	$(DOCKER_RUN) $(CALICO_BUILD) golangci-lint run $(LINT_ARGS)
+	$(DOCKER_RUN) $(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) golangci-lint run $(LINT_ARGS)'
 
 .PHONY: go-fmt goimports fix
 fix go-fmt goimports:


### PR DESCRIPTION
Cherry pick of #200 on v0.50.

#200: add git ssh for golang-ci-lint target