### PR TITLE
Dep was officially deprecated

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -77,7 +77,6 @@ RUN cp -a $GOROOT $GOCGO && \
 # Install go programs that we rely on
 ENV GLIDE_HOME /home/user/.glide
 RUN go get github.com/Masterminds/glide && \
-  go get github.com/golang/dep/cmd/dep && \
   go get github.com/onsi/ginkgo/ginkgo && \
   go get golang.org/x/tools/cmd/goimports && \
   wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.27.0 && \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -47,9 +47,6 @@ RUN go install -v std
 RUN go get github.com/Masterminds/glide
 ENV GLIDE_HOME /home/user/.glide
 
-# Install dep
-RUN go get github.com/golang/dep/cmd/dep
-
 # Install ginkgo CLI tool for running tests
 RUN go get github.com/onsi/ginkgo/ginkgo
 

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -47,9 +47,6 @@ RUN go install -v std
 RUN go get github.com/Masterminds/glide
 ENV GLIDE_HOME /home/user/.glide
 
-# Install dep
-RUN go get github.com/golang/dep/cmd/dep
-
 # Install ginkgo CLI tool for running tests
 RUN go get github.com/onsi/ginkgo/ginkgo
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -47,9 +47,6 @@ RUN go install -v std
 RUN go get github.com/Masterminds/glide
 ENV GLIDE_HOME /home/user/.glide
 
-# Install dep
-RUN go get github.com/golang/dep/cmd/dep
-
 # Install ginkgo CLI tool for running tests
 RUN go get github.com/onsi/ginkgo/ginkgo
 


### PR DESCRIPTION
since in 2020, dep has been officially deprecated by golang, I think it is possible to give up using dep. Please refer to dep community [golang/dep](https://github.com/golang/dep)，please refer to all issues and prs closed by the dep community last year.

