### PR TITLE
Fix tag builds

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -13,6 +13,8 @@ global_job_config:
     - name: docker-hub
   prologue:
     commands:
+      # This login uses the basic credentials for pulling images.  The jobs that need to push will use the
+      # push-enabled secret below.
       - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
       - >
         if [ $SEMAPHORE_GIT_REF_TYPE = "tag" ]; then
@@ -56,6 +58,7 @@ blocks:
     jobs:
     - name: Build and push image
       commands:
+      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
       - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
       - make image ARCH=$ARCH
       - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make push ARCH=$ARCH CONFIRM=true; fi
@@ -75,6 +78,7 @@ blocks:
     jobs:
     - name: Push multi-arch manifest
       commands:
+      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
       - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
       - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make push-manifest CONFIRM=true; fi
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,6 +14,14 @@ global_job_config:
   prologue:
     commands:
       - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
+      - >
+        if [ $SEMAPHORE_GIT_REF_TYPE = "tag" ]; then
+          export BRANCH_NAME=$SEMAPHORE_GIT_TAG;
+        else
+          export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH;
+        fi;
+      - export VERSION=$BRANCH_NAME
       - checkout
       # Semaphore is doing shallow clone on a commit without tags.
       # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always) @ Makefile.common
@@ -49,10 +57,6 @@ blocks:
     jobs:
     - name: Build and push image
       commands:
-      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
-      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
-      - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
-      - export VERSION=$BRANCH_NAME
       - make image ARCH=$ARCH
       - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make push ARCH=$ARCH CONFIRM=true; fi
       matrix:
@@ -71,9 +75,5 @@ blocks:
     jobs:
     - name: Push multi-arch manifest
       commands:
-      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
-      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
-      - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
-      - export VERSION=$BRANCH_NAME
       - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make push-manifest CONFIRM=true; fi
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,7 +14,6 @@ global_job_config:
   prologue:
     commands:
       - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
-      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
       - >
         if [ $SEMAPHORE_GIT_REF_TYPE = "tag" ]; then
           export BRANCH_NAME=$SEMAPHORE_GIT_TAG_NAME;
@@ -57,6 +56,7 @@ blocks:
     jobs:
     - name: Build and push image
       commands:
+      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
       - make image ARCH=$ARCH
       - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make push ARCH=$ARCH CONFIRM=true; fi
       matrix:
@@ -75,5 +75,6 @@ blocks:
     jobs:
     - name: Push multi-arch manifest
       commands:
+      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
       - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make push-manifest CONFIRM=true; fi
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -17,7 +17,7 @@ global_job_config:
       - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
       - >
         if [ $SEMAPHORE_GIT_REF_TYPE = "tag" ]; then
-          export BRANCH_NAME=$SEMAPHORE_GIT_TAG;
+          export BRANCH_NAME=$SEMAPHORE_GIT_TAG_NAME;
         else
           export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH;
         fi;

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -69,7 +69,7 @@ blocks:
 - name: "Push manifest"
   skip:
     # Only run on branches, not PRs.
-    when: "branch !~ '.+'"
+    when: "branch !~ '.+' AND tag !~ '.*'"
   dependencies: ["Build images"]
   task:
     secrets:


### PR DESCRIPTION
Previously, builds of tags were failing because the BRANCH_NAME got set to the wrong value.