### PR TITLE
Add release target helpers

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -94,6 +94,9 @@ ifeq ($(RELEASE),true)
 PUSH_IMAGES+=$(RELEASE_IMAGES)
 endif
 
+# Convenience function to get the first dev image repo in the list.
+DEV_REGISTRY ?= $(firstword $(DEV_REGISTRIES))
+
 # remove from the list to push to manifest any registries that do not support multi-arch
 EXCLUDE_MANIFEST_REGISTRIES ?= quay.io/
 PUSH_MANIFEST_IMAGES=$(PUSH_IMAGES:$(EXCLUDE_MANIFEST_REGISTRIES)%=)
@@ -346,8 +349,15 @@ endif
 git-commit:
 	git diff --quiet HEAD || git commit -m "Semaphore Automatic Update" go.mod go.sum $(EXTRA_FILES_TO_COMMIT)
 
-git-push:
-	git push
+ifdef DRYRUN
+crane-cp 	= $(shell echo echo [DRY RUN] crane cp $(1) $(2))
+git-push 	= $(shell echo echo [DRY RUN] git push $(1) $(2))
+docker-push = $(shell echo echo [DRY RUN] docker push $1)
+else
+crane-cp 	= $(shell echo crane cp $(1) $(2))
+git-push 	= $(shell echo git push $(1) $(2))
+docker-push = $(shell echo docker push $1)
+endif
 
 commit-and-push-pr:
 	git add $(GIT_COMMIT_FILES)
@@ -683,13 +693,21 @@ ifndef IMAGETAG
 	$(error IMAGETAG is undefined - run using make <target> IMAGETAG=X.Y.Z)
 endif
 
-sub-single-tag-images-arch-%:
+sub-single-tag-images-arch-%: var-require-one-of-BUILD_IMAGES-BUILD_IMAGE
+ifdef BUILD_IMAGES
+	$(foreach build_image,$(BUILD_IMAGES),$(shell docker tag $(build_image):latest-$(ARCH) $(call unescapefs,$*:$(IMAGETAG)-$(ARCH))))
+else
 	docker tag $(BUILD_IMAGE):latest-$(ARCH) $(call unescapefs,$*:$(IMAGETAG)-$(ARCH))
+endif
 
 # because some still do not support multi-arch manifest
-sub-single-tag-images-non-manifest-%:
+sub-single-tag-images-non-manifest-%: var-require-one-of-BUILD_IMAGES-BUILD_IMAGE
 ifeq ($(ARCH),amd64)
+ifdef BUILD_IMAGES
+	$(foreach build_image,$(BUILD_IMAGES),$(shell docker tag $(build_image):latest-$(ARCH) $(call unescapefs,$*:$(IMAGETAG))))
+else
 	docker tag $(BUILD_IMAGE):latest-$(ARCH) $(call unescapefs,$*:$(IMAGETAG))
+endif
 else
 	$(NOECHO) $(NOOP)
 endif
@@ -703,7 +721,7 @@ sub-tag-images-%:
 push: imagetag $(addprefix sub-single-push-,$(call escapefs,$(PUSH_IMAGES)))
 
 sub-single-push-%:
-	docker push $(call unescapefs,$*:$(IMAGETAG)-$(ARCH))
+	$(call docker-push, $(call unescapefs,$*:$(IMAGETAG)-$(ARCH)))
 
 push-all: imagetag $(addprefix sub-push-,$(VALIDARCHES))
 sub-push-%:
@@ -713,7 +731,7 @@ sub-push-%:
 push-non-manifests: imagetag $(addprefix sub-non-manifest-,$(call escapefs,$(PUSH_NONMANIFEST_IMAGES)))
 sub-non-manifest-%:
 ifeq ($(ARCH),amd64)
-	docker push $(call unescapefs,$*:$(IMAGETAG))
+	$(call docker-push, $(call unescapefs,$*:$(IMAGETAG)))
 else
 	$(NOECHO) $(NOOP)
 endif
@@ -739,9 +757,195 @@ endif
 
 # cd-common tags and pushes images with the branch name and git version. This target uses PUSH_IMAGES, BUILD_IMAGE,
 # and BRANCH_NAME env variables to figure out what to tag and where to push it to.
-cd-common: require-confirm require-branch-name
+cd-common: var-require-one-of-CONFIRM-DRYRUN var-require-all-BRANCH_NAME
 	$(MAKE) tag-images-all push-all push-manifests push-non-manifests IMAGETAG=$(BRANCH_NAME) EXCLUDEARCH="$(EXCLUDEARCH)"
 	$(MAKE) tag-images-all push-all push-manifests push-non-manifests IMAGETAG=$(shell git describe --tags --dirty --long --always --abbrev=12) EXCLUDEARCH="$(EXCLUDEARCH)"
+
+###############################################################################
+# Release targets and helpers
+#
+# The followings targets and macros are used to help start and cut releases.
+# At high level, this involves:
+# - Creating release branches
+# - Adding empty commits to start next release, and updating the 'dev' tag
+# - Adding 'release' tag to the commit that will be release
+# - Creating an empty commit for the next potential patch release, and updating
+#   the dev tag on that commit
+# - Copying images for the released commit over to the release registries, and
+#   re tagging those images with the release tag
+#
+# The following definitions will be helpful in understanding this process:
+# - 'dev' tag: A git tag of the form of `v3.8.0-calient-0.dev-36-g3a618e61c2d3`
+#   that every commit has. The start of the dev tag, i.e. v3.8.0, is the
+#   the release that this commit will go into.
+# - 'release' tag: A git tag of the form of `v3.8.0`. The commit that a release
+#   is cut from will have this tag, i.e. you can find the commit that release
+#   3.8 uses by finding the commit with the tag v3.8.0.
+# - 'dev' image: The image that is created for evey commit that is merged to
+#   master or a release branch. This image is tagged with the dev tag, i.e.
+#   if commit 3a618e61c2d3 is on master or a release branch, there will be
+#   an image for that commit in the dev registry with the tag
+#   `v3.8.0-calient-0.dev-36-g3a618e61c2d3`.
+# - 'release' image: The public image the customers will use to install our
+#   our product. Producing this is the goal of cutting the release. This image
+#   will be in the release registries, and will be tagged with the release tag,
+#   i.e. the release image for release 3.8 will have the v3.8.0 tag, or if it's
+#   a patch release it will be v3.8.<patch version>
+###############################################################################
+fetch-all:
+	git fetch --all -q
+
+# git-dev-tag retrieves the dev tag for the current commit (the one are dev images are tagged with).
+git-dev-tag = $(shell git describe --tags --long --always --abbrev=12 --match "*dev*")
+# git-release-tag-from-dev-tag get's the release version from the current commits dev tag.
+git-release-tag-from-dev-tag = $(shell echo $(call git-dev-tag) | grep -P -o "^v\d*.\d*.\d*")
+# git-release-tag-for-current-commit gets the release tag for the current commit if there is one.
+git-release-tag-for-current-commit = $(shell git describe --tags --exact-match --exclude "*dev*")
+
+# release-branch-for-tag finds the latest branch that corresponds to the given tag.
+release-branch-for-tag = $(firstword $(shell git --no-pager branch --format='%(refname:short)' --contains $1 | grep -P "^release"))
+# commit-for-tag finds the latest commit that corresponds to the given tag.
+commit-for-tag = $(shell git rev-list -n 1 $1)
+git-commit-for-remote-tag = $(shell git ls-remote -q --tags $(GIT_REMOTE) $1 | awk '{print $$1}')
+# current-branch gets the name of the branch for the current commit.
+current-branch = $(shell git rev-parse --abbrev-ref HEAD)
+
+# var-set-% checks if there is a non empty variable for the value describe by %. If FAIL_NOT_SET is set, then var-set-%
+# fails with an error message. If FAIL_NOT_SET is not set, then var-set-% appends a 1 to VARSET if the variable isn't
+# set.
+var-set-%:
+	$(if $($*),$(eval VARSET+=1),$(if $(FAIL_NOT_SET),$(error $* is required but not set),))
+
+# var-require is used to check if one or all of the variables are set in REQUIRED_VARS, and fails if not. The variables
+# in REQUIRE_VARS are hyphen separated.
+#
+# If FAIL_NOT_SET is set, then all variables described in REQUIRED_VARS must be set for var-require to not fail,
+# otherwise only one variable needs to be set for var-require to not fail.
+var-require: $(addprefix var-set-,$(subst -, ,$(REQUIRED_VARS)))
+	$(if $(VARSET),,$(error one of $(subst -, ,$(REQUIRED_VARS)) is not set or empty, but at least one is required))
+
+# var-require-all-% checks if the there are non empty variables set for the hyphen separated values in %, and fails if
+# there isn't a non empty variable for each given value. For instance, to require FOO and BAR both must be set you would
+# call var-require-all-FOO-BAR.
+var-require-all-%:
+	$(MAKE) var-require REQUIRED_VARS=$* FAIL_NOT_SET=true
+
+# var-require-one-of-% checks if the there are non empty variables set for the hyphen separated values in %, and fails
+# there isn't a non empty variable for at least one of the given values. For instance, to require either FOO or BAR both
+# must be set you would call var-require-all-FOO-BAR.
+var-require-one-of-%:
+	$(MAKE) var-require REQUIRED_VARS=$*
+
+sem-cut-release: var-require-one-of-CONFIRM-DRYRUN var-require-one-of-USE_CURRENT_DEV_TAG-USE_CURRENT_DEV_TAG
+	$(if $(USE_CURRENT_DEV_TAG),$(eval TAG = $(call git-dev-tag)))
+	@echo "Cutting release from commit tagged with $(TAG)"
+	SEMAPHORE_WORKFLOW_BRANCH=$(call release-branch-for-tag,$(TAG)) SEMAPHORE_COMMIT_SHA=$(call commit-for-tag,$(TAG)) SEMAPHORE_WORKFLOW_FILE=cut-release.yml $(MAKE) semaphore-run-workflow
+
+# cut-release uses the dev tags on the current commit to cut the release, more specifically cut-release does the
+# following:
+# - Calculates the release tag from the dev tag on the commit
+# - tags the current commit with the release tag then pushes that tag to github
+# - retags the build images (specified by BUILD_IMAGES) in the dev registries (specified DEV_REGISTRIES) with the
+#	release tag
+# - copies the build images (specified by BUILD_IMAGES) from the first dev registry to the release registries (specified
+#	by RELEASE_REGISTRIES) and retags those images with the release tag
+# - tags an empty commit at the head of the release branch with the next patch release dev tag and pushed that to github
+cut-release: var-require-one-of-CONFIRM-DRYRUN
+	$(eval DEV_TAG = $(call git-dev-tag))
+	$(eval RELEASE_TAG = $(call git-release-tag-from-dev-tag))
+	$(eval RELEASE_BRANCH = $(call release-branch-for-tag,$(DEV_TAG)))
+	$(eval NEXT_RELEASE_VERSION = $(shell echo "$(call git-release-tag-from-dev-tag)" | awk -F  "." '{print $$1"."$$2"."$$3+1}'))
+	$(MAKE) maybe-tag-release maybe-push-release-tag release-dev-images maybe-dev-tag-next-release maybe-push-next-release-dev-tag\
+		RELEASE_TAG=$(RELEASE_TAG) NEXT_RELEASE_VERSION=$(NEXT_RELEASE_VERSION) BRANCH=$(RELEASE_BRANCH) DEV_TAG=$(DEV_TAG)
+
+# maybe-tag-release calls the tag-release target only if the current commit is not tagged with the tag in RELEASE_TAG.
+# If the current commit is already tagged with the value in RELEASE_TAG then this is a NOOP.
+maybe-tag-release: var-require-all-RELEASE_TAG
+	$(if $(filter-out $(call git-release-tag-for-current-commit),$(RELEASE_TAG)),\
+		$(MAKE) tag-release,\
+		@echo "Current commit already tagged with $(RELEASE_TAG)")
+
+# tag-release tags the current commit with an annotated tag with the value in RELEASE_TAG. This target throws an error
+# if the current branch is master.
+tag-release: var-require-one-of-CONFIRM-DRYRUN var-require-all-DEV_TAG_SUFFIX-RELEASE_TAG
+	$(if $(filter-out master,$(call current-branch)),,$(error tag-release cannot be called on master))
+	git tag -a $(RELEASE_TAG) -m "Release $(RELEASE_TAG)"
+
+# maybe-push-release-tag calls the push-release-tag target only if the tag in RELEASE_TAG is not already pushed to
+# github. If the tag is pushed to github then this is a NOOP.
+# TODO should we check the commit tagged in remote is the current commit? Probably yes... that could catch some annoying problems that would be hard to find if they happened...
+maybe-push-release-tag: var-require-all-RELEASE_TAG
+	$(if $(shell git ls-remote -q --tags $(GIT_REMOTE) $(RELEASE_TAG)),\
+		@echo Release $(RELEASE_TAG) already in github,\
+		$(MAKE) push-release-tag)
+
+# push-release-tag pushes the tag in RELEASE_TAG to github. If the current commit is not tagged with this tag then this
+# target fails.
+push-release-tag: var-require-one-of-CONFIRM-DRYRUN var-require-all-DEV_TAG_SUFFIX-RELEASE_TAG
+	$(if $(call git-release-tag-for-current-commit),,$(error Commit does not have a release tag))
+	$(call git-push,$(GIT_REMOTE),$(RELEASE_TAG))
+
+# maybe-dev-tag-next-release calls the dev-tag-next-release-target only if the tag NEXT_RELEASE_VERSION-DEV_TAG_SUFFIX
+# doesn't exist locally. If the tag does exist then this is a NOOP.
+maybe-dev-tag-next-release: var-require-all-NEXT_RELEASE_VERSION-DEV_TAG_SUFFIX
+	$(if $(shell git rev-parse --verify -q "$(NEXT_RELEASE_VERSION)-$(DEV_TAG_SUFFIX)"),\
+		echo "Tag for next release $(NEXT_RELEASE_VERSION) already exists$(comma) not creating.",\
+		$(MAKE) dev-tag-next-release)
+
+# dev-tag-next-release creates a new commit empty commit at the head of BRANCH and tags it with
+# NEXT_RELEASE_VERSION-DEV_TAG_SUFFIX.
+dev-tag-next-release: var-require-one-of-CONFIRM-DRYRUN var-require-all-NEXT_RELEASE_VERSION-DEV_TAG_SUFFIX-BRANCH
+	git checkout $(BRANCH)
+	git pull $(GIT_REMOTE) $(BRANCH)
+	git commit --allow-empty -m "Begin development on $(NEXT_RELEASE_VERSION)"
+	git tag $(NEXT_RELEASE_VERSION)-$(DEV_TAG_SUFFIX)
+
+# maybe-push-next-release-dev-tag calls the push-next-release-dev-tag target if the tag
+# NEXT_RELEASE_VERSION-DEV_TAG_SUFFIX doesn't exist remotely. If the tag exists remotely then this is a NOOP.
+maybe-push-next-release-dev-tag: var-require-one-of-CONFIRM-DRYRUN var-require-all-NEXT_RELEASE_VERSION-DEV_TAG_SUFFIX
+	$(if $(shell git ls-remote --tags $(GIT_REMOTE) $(NEXT_RELEASE_VERSION)-$(DEV_TAG_SUFFIX)),\
+		echo "Dev tag for next release $(NEXT_RELEASE_VERSION) already pushed to github.",\
+		$(MAKE) push-next-release-dev-tag)
+
+# push-next-release-dev-tag pushes the tag NEXT_RELEASE_VERSION-DEV_TAG_SUFFIX and the current branch to github. If
+# the current branch is not the head of the branch then this target fails.
+push-next-release-dev-tag: var-require-one-of-CONFIRM-DRYRUN var-require-all-NEXT_RELEASE_VERSION-DEV_TAG_SUFFIX
+	# The next release commit should always be at the head of a release branch.
+	$(if $(filter-out HEAD,$(call current-branch)),,\
+		$(error "Refusing to push commit for next release while in a detached state."))
+	$(call git-push,$(GIT_REMOTE),$(call current-branch))
+	$(call git-push,$(GIT_REMOTE),$(NEXT_RELEASE_VERSION)-$(DEV_TAG_SUFFIX))
+
+# release-dev-images releases the dev images by calling the release-tag-dev-image-% and publish-dev-image-% on each
+# value in BUILD_IMAGES. This results in retagging all the dev images with the release tag and copying the dev images
+# over to the release registries.
+release-dev-images: var-require-one-of-CONFIRM-DRYRUN var-require-all-BUILD_IMAGES $(addprefix release-retag-dev-image-,$(call escapefs, $(BUILD_IMAGES))) $(addprefix release-dev-image-,$(call escapefs, $(BUILD_IMAGES)))
+
+# release-retag-dev-image-% retags the image specified by % in the dev registries specified by DEV_REGISTRIES with the
+# tag in RELEASE_TAG.
+release-retag-dev-image-%: var-require-one-of-CONFIRM-DRYRUN var-require-all-DEV_REGISTRIES-DEV_TAG-RELEASE_TAG
+	$(foreach dev_registry,$(DEV_REGISTRIES),\
+		$(call crane-cp,$(dev_registry)/$(call unescapefs,$*):$(DEV_TAG),\
+		$(dev_registry)/$(call unescapefs,$*):$(RELEASE_TAG)))
+
+# release-dev-image-% copies and retags the image specified by % from the dev registry specified by DEV_REGISTRY to the
+# release registries specified by RELEASE_REGISTRIES using the tag in RELEASE_TAG.
+release-dev-image-%: var-require-one-of-CONFIRM-DRYRUN var-require-all-DEV_REGISTRY-RELEASE_REGISTRIES-DEV_TAG-RELEASE_TAG
+	$(foreach release_registry,$(RELEASE_REGISTRIES),\
+		$(call crane-cp,$(DEV_REGISTRY)/$(call unescapefs,$*):$(DEV_TAG),\
+		$(release_registry)/$(call unescapefs,$*):$(RELEASE_TAG)))
+
+# create-release-branch creates a release branch based off of the dev tag for the current commit on master. After the
+# release branch is created and pushed, git-create-next-dev-tag is called to create a new empty commit on master and
+# tag that empty commit with an incremented minor version of the previous dev tag for the next release.
+create-release-branch: var-require-one-of-CONFIRM-DRYRUN var-require-all-DEV_TAG_SUFFIX-RELEASE_BRANCH_PREFIX fetch-all
+	$(if $(filter-out master,$(call current-branch)),$(error create-release-branch must be called on master),)
+	$(eval NEXT_RELEASE_VERSION := $(shell echo "$(call git-release-tag-from-dev-tag)" | awk -F  "." '{print $$1"."$$2+1"."0}'))
+	$(eval RELEASE_BRANCH_VERSION := $(shell echo "$(call git-release-tag-from-dev-tag)" | awk -F  "." '{print $$1"."$$2}'))
+	git checkout -B $(RELEASE_BRANCH_PREFIX)-$(RELEASE_BRANCH_VERSION) $(GIT_REMOTE)/master
+	$(call git-push,$(GIT_REMOTE),$(RELEASE_BRANCH_PREFIX)-$(RELEASE_BRANCH_VERSION))
+	$(MAKE) dev-tag-next-release push-next-release-dev-tag\
+ 		BRANCH=$(call current-branch) NEXT_RELEASE_VERSION=$(NEXT_RELEASE_VERSION) DEV_TAG_SUFFIX=$(DEV_TAG_SUFFIX)
 
 ###############################################################################
 # Helpers


### PR DESCRIPTION
This commit adds the targets that the repos will need for cutting releases. It includes the following:
- Targets to create new release branches and bump the dev tag for the next release on master
- Create release tags and annotate the current commit with that tag
- Retage docker images from their dev tag to their release tag and move them to the release repositories