### PR TITLE
update clang and llvm to version 11

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -33,7 +33,7 @@ RUN echo 'APT::Default-Release "stable";' > /etc/apt/apt.conf.d/99defaultrelease
         libbpf-dev linux-headers-amd64  && \
     apt-get install --no-install-recommends -y \
         curl bash git openssh-client mercurial make wget util-linux file grep sed jq zip \
-        llvm clang binutils file iproute2 \
+        llvm-11 clang-11 binutils file iproute2 \
         ca-certificates gcc mingw-w64 libc-dev bsdmainutils strace libpcap-dev && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
upgrade clang from clang-7 to clang-11. This needs to be done in order to use libbpf to load bpf programs.