### PR TITLE
Fix image tagging so that we get tags for all architectures

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -797,15 +797,11 @@ retag-build-image-with-registry-%: var-require-all-REGISTRY-BUILD_IMAGES
 # retag-build-image-arch-with-registry-% retags the build / arch image specified by $* and BUILD_IMAGE with the
 # registry specified by REGISTRY.
 retag-build-image-arch-with-registry-%: var-require-all-REGISTRY-BUILD_IMAGE-IMAGETAG
-# If the registry we want to push to doesn't not support manifests don't push the ARCH image.
-ifeq ($(filter $(NONMANIFEST_REGISTRIES),$(REGISTRY)),)
 	docker tag $(BUILD_IMAGE):$(LATEST_IMAGE_TAG)-$* $(call filter-registry,$(REGISTRY))$(BUILD_IMAGE):$(IMAGETAG)-$*
-else
 	$(if $(filter $*,amd64),\
 		docker tag $(BUILD_IMAGE):$(LATEST_IMAGE_TAG)-$(ARCH) $(REGISTRY)/$(BUILD_IMAGE):$(IMAGETAG),\
 		$(NOECHO) $(NOOP)\
 	)
-endif
 
 # push-images-to-registries pushes the build / arch images specified by BUILD_IMAGES and VALIDARCHES to the registries
 # specified by DEV_REGISTRY.
@@ -825,14 +821,11 @@ push-image-to-registry-%:
 # specified by REGISTRY.
 push-image-arch-to-registry-%:
 # If the registry we want to push to doesn't not support manifests don't push the ARCH image.
-ifeq ($(filter $(NONMANIFEST_REGISTRIES),$(REGISTRY)),)
 	$(DOCKER) push $(call filter-registry,$(REGISTRY))$(BUILD_IMAGE):$(IMAGETAG)-$*
-else
 	$(if $(filter $*,amd64),\
 		$(DOCKER) push $(REGISTRY)/$(BUILD_IMAGE):$(IMAGETAG),\
 		$(NOECHO) $(NOOP)\
 	)
-endif
 
 manifest-tool-generate-spec: var-require-all-BUILD_IMAGE-IMAGETAG-MANIFEST_TOOL_SPEC_TEMPLATE-OUTPUT_FILE
 	bash $(MANIFEST_TOOL_SPEC_TEMPLATE) $(OUTPUT_FILE) $(BUILD_IMAGE) $(IMAGETAG)


### PR DESCRIPTION
The previous logic was bugged - we want the code to always push images
tagged with -ARCH, and only sometimes push manifest images.