### PR TITLE
Update api repo pin update target

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -327,7 +327,7 @@ CNI_BRANCH?=$(PIN_BRANCH)
 CNI_REPO?=github.com/projectcalico/cni-plugin
 
 update-api-pin:
-	$(call update_pin,github.com/projectcalico/api,$(API_REPO),$(API_BRANCH))
+	$(call update_pin,$(API_REPO),$(API_REPO),$(API_BRANCH))
 
 replace-api-pin:
 	$(call update_replace_pin,github.com/projectcalico/api,$(API_REPO),$(API_BRANCH))


### PR DESCRIPTION
We use projectcalico/api in opensource and tigera/api for commercial repos. This update should use the right repo depending on how API_REPO is set.

This pin/repo/lib is also used differently that some of the other repos where we tend to replace projectcalico repos with tigera repos.