### PR TITLE
Pin generation tools

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -87,13 +87,13 @@ RUN go get github.com/Masterminds/glide && \
   go get -u golang.org/x/vgo && \
   go get -u github.com/jstemmer/go-junit-report && \
   go get -u golang.org/x/tools/cmd/stringer && \
-  go get -u k8s.io/code-generator/cmd/openapi-gen && \
-  go get -u k8s.io/code-generator/cmd/deepcopy-gen && \
-  go get -u k8s.io/code-generator/cmd/client-gen && \
-  go get -u k8s.io/code-generator/cmd/lister-gen && \
-  go get -u k8s.io/code-generator/cmd/informer-gen && \
-  go get -u k8s.io/code-generator/cmd/defaulter-gen && \
-  go get -u k8s.io/code-generator/cmd/conversion-gen && \
+  GO111MODULE=on go get -u k8s.io/code-generator/cmd/openapi-gen@v0.21.0-beta.1 && \
+  GO111MODULE=on go get -u k8s.io/code-generator/cmd/deepcopy-gen@v0.21.0-beta.1 && \
+  GO111MODULE=on go get -u k8s.io/code-generator/cmd/client-gen@v0.21.0-beta.1 && \
+  GO111MODULE=on go get -u k8s.io/code-generator/cmd/lister-gen@v0.21.0-beta.1 && \
+  GO111MODULE=on go get -u k8s.io/code-generator/cmd/informer-gen@v0.21.0-beta.1 && \
+  GO111MODULE=on go get -u k8s.io/code-generator/cmd/defaulter-gen@v0.21.0-beta.1 && \
+  GO111MODULE=on go get -u k8s.io/code-generator/cmd/conversion-gen@v0.21.0-beta.1 && \
   rm -rf /go/src/* /root/.cache
 
 # Used for generating CRD files.


### PR DESCRIPTION
This pins them to what I believe we were using before, and what is consistent with the k8s imports in our projects.

Separately, we should update the versions of these tools and our k8s libraries to not be on a RC version!