### PR TITLE
[v0.55] Auto pick #332: Don't cut release images if the project doesn't have any

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -951,8 +951,14 @@ cut-release: var-require-one-of-CONFIRM-DRYRUN
 	$(eval RELEASE_TAG = $(call git-release-tag-from-dev-tag))
 	$(eval RELEASE_BRANCH = $(call release-branch-for-tag,$(DEV_TAG)))
 	$(eval NEXT_RELEASE_VERSION = $(shell echo "$(call git-release-tag-from-dev-tag)" | awk -F  "." '{print $$1"."$$2"."$$3+1}'))
-	$(MAKE) maybe-tag-release maybe-push-release-tag release-dev-images maybe-dev-tag-next-release maybe-push-next-release-dev-tag\
-		RELEASE_TAG=$(RELEASE_TAG) NEXT_RELEASE_VERSION=$(NEXT_RELEASE_VERSION) BRANCH=$(RELEASE_BRANCH) DEV_TAG=$(DEV_TAG)
+	$(MAKE) maybe-tag-release maybe-push-release-tag\
+		RELEASE_TAG=$(RELEASE_TAG) BRANCH=$(RELEASE_BRANCH) DEV_TAG=$(DEV_TAG)
+ifdef BUILD_IMAGES
+	$(MAKE) release-dev-images\
+		RELEASE_TAG=$(RELEASE_TAG) BRANCH=$(RELEASE_BRANCH) DEV_TAG=$(DEV_TAG)
+endif
+	$(MAKE) maybe-dev-tag-next-release maybe-push-next-release-dev-tag\
+		NEXT_RELEASE_VERSION=$(NEXT_RELEASE_VERSION) BRANCH=$(RELEASE_BRANCH) DEV_TAG=$(DEV_TAG)
 
 # maybe-tag-release calls the tag-release target only if the current commit is not tagged with the tag in RELEASE_TAG.
 # If the current commit is already tagged with the value in RELEASE_TAG then this is a NOOP.


### PR DESCRIPTION
Cherry pick of #332 on v0.55.

#332: Don't cut release images if the project doesn't have any