### PR TITLE
Make `make check-fmt` fail (as well as listing) if any incorrect formatting

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -30,7 +30,7 @@ RUN echo 'APT::Default-Release "buster";' > /etc/apt/apt.conf.d/99defaultrelease
     apt-get -y update &&  \
     apt-get -y upgrade && \
     apt-get install --no-install-recommends -y -t buster-backports \
-        libbpf-dev linux-headers-5.10.0-0.bpo.8-amd64  && \
+        libbpf-dev linux-headers-5.10.0-0.bpo.9-amd64  && \
     apt-get install --no-install-recommends -y \
         curl bash git openssh-client mercurial make wget util-linux file grep sed jq zip \
         llvm-11 clang-11 binutils file iproute2 \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -36,13 +36,13 @@ RUN echo 'APT::Default-Release "buster";' > /etc/apt/apt.conf.d/99defaultrelease
     apt-get -y update &&  \
     apt-get -y upgrade && \
     apt-get install --no-install-recommends -y -t buster-backports \
-        libbpf-dev linux-headers-5.10.0-0.bpo.8-arm64 && \
+        libbpf-dev linux-headers-5.10.0-0.bpo.9-arm64 && \
     apt-get install --no-install-recommends -y \
         curl bash git openssh-client mercurial make wget util-linux file grep sed jq zip \
         llvm-11 clang-11 binutils file iproute2 \
-        ca-certificates gcc libc-dev bsdmainutils strace libpcap-dev && \ 
+        ca-certificates gcc libc-dev bsdmainutils strace libpcap-dev && \
     rm -rf /var/lib/apt/lists/*
-    
+
 
 # su-exec is used by the entrypoint script to execute the user's command with the right UID/GID.
 # (sudo doesn't work easily in a container.)  The version was current master at the time of writing.

--- a/Makefile.common
+++ b/Makefile.common
@@ -112,7 +112,7 @@ filter-registry ?= $(if $(filter-out $(1),$(DOCKERHUB_REGISTRY)),$(1)/)
 DEV_REGISTRY ?= $(firstword $(DEV_REGISTRIES))
 
 # remove from the list to push to manifest any registries that do not support multi-arch
-NONMANIFEST_REGISTRIES      ?= 
+NONMANIFEST_REGISTRIES      ?=
 MANIFEST_REGISTRIES         ?= $(DEV_REGISTRIES:$(NONMANIFEST_REGISTRIES)%=)
 
 PUSH_MANIFEST_IMAGES := $(foreach registry,$(MANIFEST_REGISTRIES),$(foreach image,$(BUILD_IMAGES),$(call filter-registry,$(registry))$(image)))
@@ -551,7 +551,7 @@ fix go-fmt goimports:
 
 check-fmt:
 	@echo "Checking code formatting.  Any listed files don't match goimports:"
-	$(DOCKER_RUN) $(CALICO_BUILD) sh -c 'find . -iname "*.go" ! -wholename "./vendor/*" | xargs goimports -l -local github.com/projectcalico/'
+	$(DOCKER_RUN) $(CALICO_BUILD) bash -c 'exec 5>&1; ! [[ `find . -iname "*.go" ! -wholename "./vendor/*" | xargs goimports -l -local github.com/projectcalico/ | tee >(cat >&5)` ]]'
 
 .PHONY: pre-commit
 pre-commit:


### PR DESCRIPTION
`! [[ ... ]]` gives us an exit code of 0 or non-0, according as there is any output between the parentheses, i.e. any listed incorrectly formatted files.

Note, `[[ ... ]]` seems to handle multiple words better than `[ ... ]`:
```
neil@glaurung:~$ [[ `echo a s` ]]
neil@glaurung:~$ echo $?
0
neil@glaurung:~$ [ `echo a s` ]
bash: [: a: unary operator expected
```

`>(cat >&5)` is a "process substitution", and appears to `tee` as a filename for it to write to.