### PR TITLE
Use golang 1.17.5 (and goboring for amd64)

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -3,8 +3,9 @@ FROM calico/bpftool:v5.3-amd64 as bpftool
 FROM goboring/golang:1.16.7b7
 MAINTAINER Shaun Crampton <shaun@projectcalico.org>
 
-# Override the go boring version in the image with the latest patch.
-ARG GO_BORING_VERSION=1.16.10b7
+# Override the go boring version in the image with the latest release. There is currently no 1.17 container image,
+# so starting with 1.16 and then overwriting with 1.17.
+ARG GO_BORING_VERSION=1.17.5b7
 ARG QEMU_VERSION=4.2.0-6
 
 # we need these two distinct lists. The first one is the names used by the qemu distributions

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -12,7 +12,7 @@ RUN apt update && apt install -y curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm64v8/golang:1.16.7-buster
+FROM arm64v8/golang:1.17.5-buster
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2
 

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm32v7/golang:1.16-alpine3.14
+FROM arm32v7/golang:1.17.5-alpine3.14
 MAINTAINER Marc Crebassa <aalaesar@gmail.com>
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM ppc64le/golang:1.16-alpine3.14
+FROM ppc64le/golang:1.17.5-alpine3.14
 MAINTAINER David Wilder <wilder@ibm.com>
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM s390x/golang:1.16.7-alpine3.14
+FROM s390x/golang:1.17.5-alpine3.14
 MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2


### PR DESCRIPTION
More CVE mitigation.

Use golang 1.17