### PR TITLE
Updates go get -> go install

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -87,22 +87,22 @@ RUN cp -a $GOROOT $GOCGO && \
   rm -rf /go/src/* /root/.cache
 
 # Install go programs that we rely on
-RUN go get github.com/onsi/ginkgo/ginkgo && \
-  go get golang.org/x/tools/cmd/goimports && \
+RUN go get github.com/onsi/ginkgo/ginkgo@v1.16.5 && \
+  go install golang.org/x/tools/cmd/goimports@v0.1.8 && \
   wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.27.0 && \
   golangci-lint --version && \
   go get github.com/pmezard/licenses && \
   go get github.com/wadey/gocovmerge && \
-  GO111MODULE=on go get github.com/mikefarah/yq/v3 && \
-  go get -u github.com/jstemmer/go-junit-report && \
-  go get -u golang.org/x/tools/cmd/stringer && \
-  GO111MODULE=on go get k8s.io/code-generator/cmd/openapi-gen@v0.21.0 && \
-  GO111MODULE=on go get k8s.io/code-generator/cmd/deepcopy-gen@v0.21.0 && \
-  GO111MODULE=on go get k8s.io/code-generator/cmd/client-gen@v0.21.0 && \
-  GO111MODULE=on go get k8s.io/code-generator/cmd/lister-gen@v0.21.0 && \
-  GO111MODULE=on go get k8s.io/code-generator/cmd/informer-gen@v0.21.0 && \
-  GO111MODULE=on go get k8s.io/code-generator/cmd/defaulter-gen@v0.21.0 && \
-  GO111MODULE=on go get k8s.io/code-generator/cmd/conversion-gen@v0.21.0 && \
+  go get github.com/mikefarah/yq/v3 && \
+  go install github.com/jstemmer/go-junit-report@v0.9.1 && \
+  go install golang.org/x/tools/cmd/stringer@v0.1.8 && \
+  go install k8s.io/code-generator/cmd/openapi-gen@v0.21.0 && \
+  go install k8s.io/code-generator/cmd/deepcopy-gen@v0.21.0 && \
+  go install k8s.io/code-generator/cmd/client-gen@v0.21.0 && \
+  go install k8s.io/code-generator/cmd/lister-gen@v0.21.0 && \
+  go install k8s.io/code-generator/cmd/informer-gen@v0.21.0 && \
+  go install k8s.io/code-generator/cmd/defaulter-gen@v0.21.0 && \
+  go install k8s.io/code-generator/cmd/conversion-gen@v0.21.0 && \
   rm -rf /go/src/* /root/.cache
 
 # Install necessary Kubernetes binaries used in tests.


### PR DESCRIPTION
Don't need this for the current CVE push - but putting it out there for the next release of go-build

Update to use the preferred go install (removes deprecation warnings) and adds explicit pins for some of the go installs.  I've left a couple as `go get` since they aren't versioned.