### PR TITLE
Fix MANIFEST_REGISTRIES so it handles empty NONMANIFEST_REGISTRIES

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -113,7 +113,7 @@ DEV_REGISTRY ?= $(firstword $(DEV_REGISTRIES))
 
 # remove from the list to push to manifest any registries that do not support multi-arch
 NONMANIFEST_REGISTRIES      ?=
-MANIFEST_REGISTRIES         ?= $(DEV_REGISTRIES:$(NONMANIFEST_REGISTRIES)%=)
+MANIFEST_REGISTRIES         ?= $(filter-out $(NONMANIFEST_REGISTRIES), $(DEV_REGISTRIES))
 
 PUSH_MANIFEST_IMAGES := $(foreach registry,$(MANIFEST_REGISTRIES),$(foreach image,$(BUILD_IMAGES),$(call filter-registry,$(registry))$(image)))
 


### PR DESCRIPTION
The way MANIFEST_REGISTRIES is handled results in an empty MANIFEST_REGISTRIES value if NONMANIFEST_REGISTRIES is empty. Instead use `filter-out`, which does what we want. Here's an example from the Make [manual](https://ftp.gnu.org/old-gnu/Manuals/make-3.79.1/html_chapter/make_8.html#SEC77) for filter-out:

> objects=main1.o foo.o main2.o bar.o
> mains=main1.o main2.o
>
> the following generates a list which contains all the object files not in `mains':
> $(filter-out $(mains),$(objects))
