### PR TITLE
Automated cherry pick of #368: fea(Makefile.common): add update_replace_pin_with_path #370: Bump to golang 1.17.7 and corresponding goboring for amd64 #371: Properly escape pound sign when reconstructing image for #376: Fix syntax error when CGO_ENABLED not set #377: Add targets for updating Calico monorepo pin #378: Add prometheus and ECK operator docker builder repos #380: Bump to golang 1.17.8 and corresponding goboring for amd64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
+.vscode/
 hello-*

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -5,7 +5,7 @@ MAINTAINER Shaun Crampton <shaun@projectcalico.org>
 
 # Override the go boring version in the image with the latest release. There is currently no 1.17 container image,
 # so starting with 1.16 and then overwriting with 1.17.
-ARG GO_BORING_VERSION=1.17.7b7
+ARG GO_BORING_VERSION=1.17.8b7
 ARG QEMU_VERSION=4.2.0-6
 
 # we need these two distinct lists. The first one is the names used by the qemu distributions

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -5,7 +5,7 @@ MAINTAINER Shaun Crampton <shaun@projectcalico.org>
 
 # Override the go boring version in the image with the latest release. There is currently no 1.17 container image,
 # so starting with 1.16 and then overwriting with 1.17.
-ARG GO_BORING_VERSION=1.17.5b7
+ARG GO_BORING_VERSION=1.17.7b7
 ARG QEMU_VERSION=4.2.0-6
 
 # we need these two distinct lists. The first one is the names used by the qemu distributions

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -12,7 +12,7 @@ RUN apt update && apt install -y curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm64v8/golang:1.17.5-buster
+FROM arm64v8/golang:1.17.7-buster
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -12,7 +12,7 @@ RUN apt update && apt install -y curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm64v8/golang:1.17.7-buster
+FROM arm64v8/golang:1.17.8-buster
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2
 

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm32v7/golang:1.17.5-alpine3.14
+FROM arm32v7/golang:1.17.7-alpine3.14
 MAINTAINER Marc Crebassa <aalaesar@gmail.com>
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm32v7/golang:1.17.7-alpine3.14
+FROM arm32v7/golang:1.17.8-alpine3.14
 MAINTAINER Marc Crebassa <aalaesar@gmail.com>
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM ppc64le/golang:1.17.7-alpine3.14
+FROM ppc64le/golang:1.17.8-alpine3.14
 MAINTAINER David Wilder <wilder@ibm.com>
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM ppc64le/golang:1.17.5-alpine3.14
+FROM ppc64le/golang:1.17.7-alpine3.14
 MAINTAINER David Wilder <wilder@ibm.com>
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM s390x/golang:1.17.7-alpine3.14
+FROM s390x/golang:1.17.8-alpine3.14
 MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM s390x/golang:1.17.5-alpine3.14
+FROM s390x/golang:1.17.7-alpine3.14
 MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Makefile.common
+++ b/Makefile.common
@@ -761,36 +761,36 @@ mockery-run:
 docker-compress:
 	$(eval JSONOBJ := "$(shell docker inspect $(IMAGE_NAME) | jq '.[0].Config' | jq -R '.' | sed -e 's/#/\\\#/g' ) ")
 #	Re add the entry point.
-	$(eval CHANGE := $(CHANGE)$(shell echo $(JSONOBJ) | jq -r \
+	$(eval CHANGE := $(shell echo $(CHANGE) | sed -e 's/#/\\\#/g')$(shell echo $(JSONOBJ) | jq -r \
 		"if has(\"Entrypoint\") and .Entrypoint != \"\" then \" --change 'ENTRYPOINT \(.Entrypoint)'\" else \"\" end"\
-	))
+	| sed -e 's/#/\\\#/g'))
 #	Re add the command.
-	$(eval CHANGE := $(CHANGE)$(shell echo $(JSONOBJ) | jq -r \
+	$(eval CHANGE := $(shell echo $(CHANGE) | sed -e 's/#/\\\#/g')$(shell echo $(JSONOBJ) | jq -r \
 		"if has(\"Cmd\") and .Cmd != \"\" then \" --change 'CMD \(.Cmd)'\" else \"\" end"\
-	))
+	| sed -e 's/#/\\\#/g'))
 #	Re add the working directory.
-	$(eval CHANGE := $(CHANGE)$(shell echo $(JSONOBJ) | jq -r \
+	$(eval CHANGE := $(shell echo $(CHANGE) | sed -e 's/#/\\\#/g')$(shell echo $(JSONOBJ) | jq -r \
 		"if has(\"WorkingDir\") and .WorkingDir != \"\" then \" --change 'WORKDIR \(.WorkingDir)'\" else \"\" end"\
-	))
+	| sed -e 's/#/\\\#/g'))
 #	Re add the user.
-	$(eval CHANGE := $(CHANGE)$(shell echo $(JSONOBJ) | jq -r \
+	$(eval CHANGE := $(shell echo $(CHANGE) | sed -e 's/#/\\\#/g')$(shell echo $(JSONOBJ) | jq -r \
 		"if has(\"User\") and .User != \"\" then \" --change 'USER \(.User)'\" else \"\" end"\
-	))
+	| sed -e 's/#/\\\#/g'))
 #	Re add the environment variables. .Env is an array of strings so add a "--change 'ENV <value>'" for each value in
 #	the array.
-	$(eval CHANGE := $(CHANGE)$(shell echo $(JSONOBJ) | jq -r \
+	$(eval CHANGE := $(shell echo $(CHANGE) | sed -e 's/#/\\\#/g')$(shell echo $(JSONOBJ) | jq -r \
 		"if has(\"Env\") and (.Env | length) > 0 then .Env | map(\" --change 'ENV \(.)'\") | join(\"\") else \"\" end"\
-	))
+	| sed -e 's/#/\\\#/g'))
 #	Re add the labels. .Labels is a map of label names to label values, so add a "--change 'LABEL <key> <value>'" for
 #	each map entry.
-	$(eval CHANGE := $(CHANGE)$(shell echo $(JSONOBJ) | jq -r \
+	$(eval CHANGE := $(shell echo $(CHANGE) | sed -e 's/#/\\\#/g')$(shell echo $(JSONOBJ) | jq -r \
 		"if has(\"Labels\") and (.Labels | length) > 0 then .Labels | to_entries | map(\" --change 'LABEL \(.key) \(.value)'\") | join(\"\") else \"\" end"\
-	))
+	| sed -e 's/#/\\\#/g'))
 #	Re add the exposed ports. .ExposedPorts is a map, but we're only interested in the keys of the map so for each key
 #	add "--change EXPOSE <key>".
-	$(eval CHANGE := $(CHANGE)$(shell echo $(JSONOBJ) | jq -r \
+	$(eval CHANGE := $(shell echo $(CHANGE) | sed -e 's/#/\\\#/g')$(shell echo $(JSONOBJ) | jq -r \
 		"if has(\"ExposedPorts\") and (.ExposedPorts | length) > 0 then .ExposedPorts | keys | map(\" --change 'EXPOSE \(.)'\") | join(\"\") else \"\" end"\
-	))
+	| sed -e 's/#/\\\#/g'))
 	$(eval CONTAINER_ID := $(shell docker run -d -it --entrypoint /bin/true $(IMAGE_NAME) /bin/true))
 	docker export $(CONTAINER_ID) | docker import $(CHANGE) - $(IMAGE_NAME)
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -310,10 +310,12 @@ define update_replace_pin
 		fi'
 endef
 
-# update_replace_pin_with_path is used similarly as update_replace_pin without retrieving the git version of the 
-# replacing repo. It would take parameted $(3) as the version used by go mod edit. Used for updating pins for
-# repos with a path. as git cannot resolve a version given a repo path deeper than the top repo folder.
-define update_replace_pin_with_path
+# update_replace_submodule_pin is used similarly as update_replace_pin without retrieving the git commit SHA of the 
+# replacing repo. It would take parameter $(3) as the version used by go mod edit. Used for updating pins for
+# modules or directory within a repository. as git cannot resolve a version given a repo path deeper than the top repo folder. 
+# $(1) should be the name of the package, $(2) and $(3) the repository and branch from which to update it. If $(4) is
+# specified it's treated as the module version and use in the go mod edit -replace command.
+define update_replace_submodule_pin
 	$(eval replace_repo_branch := $(if $(3),$(3),master))
 	$(eval original_repo := $(if $(4),$(1)/$(4),$(1)))
 	$(eval replace_repo := $(if $(4),$(2)/$(4),$(2)))

--- a/Makefile.common
+++ b/Makefile.common
@@ -310,9 +310,9 @@ define update_replace_pin
 		fi'
 endef
 
-# update_replace_submodule_pin is used similarly as update_replace_pin without retrieving the git commit SHA of the
+# update_replace_submodule_pin is used similarly as update_replace_pin without retrieving the git commit SHA of the 
 # replacing repo. It would take parameter $(3) as the version used by go mod edit. Used for updating pins for
-# modules or directory within a repository. as git cannot resolve a version given a repo path deeper than the top repo folder.
+# modules or directory within a repository. as git cannot resolve a version given a repo path deeper than the top repo folder. 
 # $(1) should be the name of the package, $(2) and $(3) the repository and branch from which to update it. If $(4) is
 # specified it's treated as the module version and use in the go mod edit -replace command.
 define update_replace_submodule_pin

--- a/Makefile.common
+++ b/Makefile.common
@@ -324,6 +324,7 @@ define update_replace_pin_with_path
 			go mod edit -replace $(original_repo)=$(replace_repo)@$(replace_repo_branch); \
 			go mod tidy; \
 		fi'
+endef
 
 GIT_REMOTE?=origin
 API_BRANCH?=$(PIN_BRANCH)

--- a/Makefile.common
+++ b/Makefile.common
@@ -310,9 +310,9 @@ define update_replace_pin
 		fi'
 endef
 
-# update_replace_submodule_pin is used similarly as update_replace_pin without retrieving the git commit SHA of the 
+# update_replace_submodule_pin is used similarly as update_replace_pin without retrieving the git commit SHA of the
 # replacing repo. It would take parameter $(3) as the version used by go mod edit. Used for updating pins for
-# modules or directory within a repository. as git cannot resolve a version given a repo path deeper than the top repo folder. 
+# modules or directory within a repository. as git cannot resolve a version given a repo path deeper than the top repo folder.
 # $(1) should be the name of the package, $(2) and $(3) the repository and branch from which to update it. If $(4) is
 # specified it's treated as the module version and use in the go mod edit -replace command.
 define update_replace_submodule_pin
@@ -344,6 +344,8 @@ FELIX_BRANCH?=$(PIN_BRANCH)
 FELIX_REPO?=github.com/projectcalico/felix
 CNI_BRANCH?=$(PIN_BRANCH)
 CNI_REPO?=github.com/projectcalico/cni-plugin
+CALICO_BRANCH?=$(PIN_BRANCH)
+CALICO_REPO?=github.com/projectcalico/calico
 
 update-api-pin:
 	$(call update_pin,$(API_REPO),$(API_REPO),$(API_BRANCH))
@@ -383,6 +385,12 @@ update-cni-plugin-pin:
 
 replace-cni-pin:
 	$(call update_replace_pin,github.com/projectcalico/cni-plugin,$(CNI_REPO),$(CNI_BRANCH))
+
+update-calico-pin:
+	$(call update_pin,github.com/projectcalico/calico,$(CALICO_REPO),$(CALICO_BRANCH))
+
+replace-calico-pin:
+	$(call update_replace_pin,github.com/projectcalico/calico,$(CALICO_REPO),$(CALICO_BRANCH))
 
 git-status:
 	git status --porcelain

--- a/Makefile.common
+++ b/Makefile.common
@@ -314,7 +314,7 @@ endef
 # replacing repo. It would take parameted $(3) as the version used by go mod edit. Used for updating pins for
 # repos with a path. as git cannot resolve a version given a repo path deeper than the top repo folder.
 define update_replace_pin_with_path
-	$(eval replace_repo_branch := $(if $(3),$(3),master)
+	$(eval replace_repo_branch := $(if $(3),$(3),master))
 	$(eval original_repo := $(if $(4),$(1)/$(4),$(1)))
 	$(eval replace_repo := $(if $(4),$(2)/$(4),$(2)))
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -310,6 +310,21 @@ define update_replace_pin
 		fi'
 endef
 
+# update_replace_pin_with_path is used similarly as update_replace_pin without retrieving the git version of the 
+# replacing repo. It would take parameted $(3) as the version used by go mod edit. Used for updating pins for
+# repos with a path. as git cannot resolve a version given a repo path deeper than the top repo folder.
+define update_replace_pin_with_path
+	$(eval replace_repo_branch := $(if $(3),$(3),master)
+	$(eval original_repo := $(if $(4),$(1)/$(4),$(1)))
+	$(eval replace_repo := $(if $(4),$(2)/$(4),$(2)))
+
+	$(DOCKER_RUN) -i $(CALICO_BUILD) sh -c '\
+		if [ ! -z "$(replace_repo_branch)" ]; then \
+			$(GIT_CONFIG_SSH) \
+			go mod edit -replace $(original_repo)=$(replace_repo)@$(replace_repo_branch); \
+			go mod tidy; \
+		fi'
+
 GIT_REMOTE?=origin
 API_BRANCH?=$(PIN_BRANCH)
 API_REPO?=github.com/projectcalico/api

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,7 @@ if [ -n "$EXTRA_GROUP_ID"  ]; then
   fi
 fi
 
-if [ $CGO_ENABLED = "1" ]; then
+if [ "$CGO_ENABLED" = "1" ]; then
   echo "CGO enabled, switching GOROOT to $GOCGO."
   export GOROOT=$GOCGO
   export PATH=$GOCGO/bin:$PATH


### PR DESCRIPTION
This version is skipping k8s components moving to 0.23.2 changes from #367 and cherry picks everything else till current HEAD in master
 #368 #370 #371 #376 #377 #378 #380 on v0.69.

#368: fea(Makefile.common): add update_replace_pin_with_path
#370: Bump to golang 1.17.7 and corresponding goboring for amd64
#371: Properly escape pound sign when reconstructing image for
#376: Fix syntax error when CGO_ENABLED not set
#377: Add targets for updating Calico monorepo pin
#378: Add prometheus and ECK operator docker builder repos
#380: Bump to golang 1.17.8 and corresponding goboring for amd64