### PR TITLE
Automated cherry pick of #389:  Bump to golang 1.17.9 and corresponding goboring for amd64

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -40,7 +40,7 @@ blocks:
       env_vars:
         # The branch to test the current go-build against
         - name: CALICO_BRANCH
-          value: master
+          value: release-v3.22
       matrix:
       - env_var: PROJECT
         values: ["felix", "calicoctl", "libcalico-go"]

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -33,9 +33,14 @@ blocks:
       commands:
       - git clone git@github.com:projectcalico/calico.git calico
       - cd calico
+      - git checkout "${CALICO_BRANCH}"
       - perl -0777 -pi -e's/GO_BUILD_VER\s*[?:]?=\s*\K[\.0-9a-z]+/'"${SEMAPHORE_GIT_BRANCH}"'/' metadata.mk
       - cd $PROJECT
       - make ut
+      env_vars:
+        # The branch to test the current go-build against
+        - name: CALICO_BRANCH
+          value: master
       matrix:
       - env_var: PROJECT
         values: ["felix", "calicoctl", "libcalico-go"]

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -5,7 +5,7 @@ MAINTAINER Shaun Crampton <shaun@projectcalico.org>
 
 # Override the go boring version in the image with the latest release. There is currently no 1.17 container image,
 # so starting with 1.16 and then overwriting with 1.17.
-ARG GO_BORING_VERSION=1.17.8b7
+ARG GO_BORING_VERSION=1.17.9b7
 ARG QEMU_VERSION=4.2.0-6
 
 # we need these two distinct lists. The first one is the names used by the qemu distributions

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -12,7 +12,7 @@ RUN apt update && apt install -y curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm64v8/golang:1.17.8-buster
+FROM arm64v8/golang:1.17.9-buster
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2
 

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm32v7/golang:1.17.8-alpine3.14
+FROM arm32v7/golang:1.17.9-alpine3.14
 MAINTAINER Marc Crebassa <aalaesar@gmail.com>
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM ppc64le/golang:1.17.8-alpine3.14
+FROM ppc64le/golang:1.17.9-alpine3.14
 MAINTAINER David Wilder <wilder@ibm.com>
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM s390x/golang:1.17.8-alpine3.14
+FROM s390x/golang:1.17.9-alpine3.14
 MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2


### PR DESCRIPTION
Cherry pick of #389 on v0.65.2.

#389:  Bump to golang 1.17.9 and corresponding goboring for amd64