### PR TITLE
Fixing go lint installation URL

### DIFF
--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -47,7 +47,7 @@ RUN go install -v std
 RUN go get github.com/onsi/ginkgo/ginkgo
 
 # Install linting tools.
-RUN wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.20.0
+RUN wget -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.20.0
 RUN golangci-lint --version
 
 # Install license checking tool.


### PR DESCRIPTION
Fixing go lint installation for s390x as installation URL has changed.