### PR TITLE
Consider tigera packages as local packages

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -573,11 +573,11 @@ golangci-lint: $(GENERATED_FILES)
 
 .PHONY: go-fmt goimports fix
 fix go-fmt goimports:
-	$(DOCKER_RUN) $(CALICO_BUILD) sh -c 'find . -iname "*.go" ! -wholename "./vendor/*" | xargs goimports -w -local github.com/projectcalico/'
+	$(DOCKER_RUN) $(CALICO_BUILD) sh -c 'find . -iname "*.go" ! -wholename "./vendor/*" | xargs goimports -w -local github.com/projectcalico/,github.com/tigera/'
 
 check-fmt:
 	@echo "Checking code formatting.  Any listed files don't match goimports:"
-	$(DOCKER_RUN) $(CALICO_BUILD) bash -c 'exec 5>&1; ! [[ `find . -iname "*.go" ! -wholename "./vendor/*" | xargs goimports -l -local github.com/projectcalico/ | tee >(cat >&5)` ]]'
+	$(DOCKER_RUN) $(CALICO_BUILD) bash -c 'exec 5>&1; ! [[ `find . -iname "*.go" ! -wholename "./vendor/*" | xargs goimports -l -local github.com/projectcalico/,github.com/tigera/ | tee >(cat >&5)` ]]'
 
 .PHONY: pre-commit
 pre-commit:


### PR DESCRIPTION
We currently treat packages starting with `github.com/projectcalico/` as local ones, which formats their import in a different section. This change adds the packages starting with `github.com/tigera/`to the list of local ones so that they're listed below the ones from `github.com/projectcalico/`.

Default formatting, without any `-local` flag:
```
import (
	"flag"

	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
	"github.com/sirupsen/logrus"
	updater "github.com/tigera/runtime-security/pkg/sasha-updater"
	verify "github.com/tigera/runtime-security/pkg/verify"
)
```

Current solution, using `-local github.com/projectcalico/`:
```
import (
	"flag"

	"github.com/sirupsen/logrus"
	updater "github.com/tigera/runtime-security/pkg/sasha-updater"
	verify "github.com/tigera/runtime-security/pkg/verify"

	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
)
```

Proposed change, using `-local github.com/projectcalico/,github.com/tigera/`:
```
import (
	"flag"

	"github.com/sirupsen/logrus"

	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
	updater "github.com/tigera/runtime-security/pkg/sasha-updater"
	verify "github.com/tigera/runtime-security/pkg/verify"
)
```