### PR TITLE
Update Golang 1.18.5 for amd64

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,11 +1,9 @@
 FROM calico/bpftool:v5.3-amd64 as bpftool
 
-FROM goboring/golang:1.16.7b7
+FROM us-docker.pkg.dev/google.com/api-project-999119582588/go-boringcrypto/golang:1.18.5b7
 MAINTAINER Shaun Crampton <shaun@projectcalico.org>
 
-# Override the go boring version in the image with the latest release. There is currently no 1.17 container image,
-# so starting with 1.16 and then overwriting with 1.17.
-ARG GO_BORING_VERSION=1.18.1b7
+ARG GO_BORING_VERSION=1.18.5b7
 ARG QEMU_VERSION=4.2.0-6
 
 # we need these two distinct lists. The first one is the names used by the qemu distributions


### PR DESCRIPTION
Go boring crypto bits location is changed according to
https://go.googlesource.com/go/+/refs/heads/dev.boringcrypto/misc/boring/README.md

This PR updates the golang version for amd64