### PR TITLE
[EV-2594] Upgrade go to 1.18.8b7. Upgrade alpine to 3.16

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,9 +1,9 @@
 FROM calico/bpftool:v5.3-amd64 as bpftool
 
-FROM us-docker.pkg.dev/google.com/api-project-999119582588/go-boringcrypto/golang:1.18.7b7
+FROM us-docker.pkg.dev/google.com/api-project-999119582588/go-boringcrypto/golang:1.18.8b7
 MAINTAINER Shaun Crampton <shaun@projectcalico.org>
 
-ARG GO_BORING_VERSION=1.18.7b7
+ARG GO_BORING_VERSION=1.18.8b7
 ARG QEMU_VERSION=4.2.0-6
 
 # we need these two distinct lists. The first one is the names used by the qemu distributions

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -12,7 +12,7 @@ RUN apt update && apt install -y curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm64v8/golang:1.18.7-buster
+FROM arm64v8/golang:1.18.8-buster
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2
 

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -1,4 +1,4 @@
-FROM alpine:3.11 as qemu
+FROM alpine:3.16 as qemu
 
 ARG QEMU_VERSION=4.2.0-6
 ARG QEMU_ARCHS="arm"
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm32v7/golang:1.18.7-alpine3.16
+FROM arm32v7/golang:1.18.8-alpine3.16
 MAINTAINER Marc Crebassa <aalaesar@gmail.com>
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,4 +1,4 @@
-FROM alpine:3.11 as qemu
+FROM alpine:3.16 as qemu
 
 ARG QEMU_VERSION=4.2.0-6
 ARG QEMU_ARCHS="ppc64le"
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM ppc64le/golang:1.18.7-alpine3.16
+FROM ppc64le/golang:1.18.8-alpine3.16
 MAINTAINER David Wilder <wilder@ibm.com>
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,4 +1,4 @@
-FROM alpine:3.11 as qemu
+FROM alpine:3.16 as qemu
 
 ARG QEMU_VERSION=4.2.0-6
 ARG QEMU_ARCHS="s390x"
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM s390x/golang:1.18.7-alpine3.16
+FROM s390x/golang:1.18.8-alpine3.16
 MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2


### PR DESCRIPTION
* Upgrade go version referencing golang docker images and go-boringcrypto to `go-1.18.8b7` from `go-1.18.7b7`
* Upgrade alpine docker image to `3.16` from `3.11`

[References]
https://hub.docker.com/_/golang
https://hub.docker.com/r/arm64v8/golang/
https://go.googlesource.com/go/+/dev.boringcrypto/misc/boring/RELEASES