### PR TITLE
update dockerfile goversion for architectures.

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -12,7 +12,7 @@ RUN apt update && apt install -y curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm64v8/golang:1.18.9-buster
+FROM arm64v8/golang:1.19.5-buster
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2
 

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -1,4 +1,4 @@
-FROM alpine:3.16 as qemu
+FROM alpine:3.17 as qemu
 
 ARG QEMU_VERSION=4.2.0-6
 ARG QEMU_ARCHS="arm"
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm32v7/golang:1.18.9-alpine3.17
+FROM arm32v7/golang:1.19.5-alpine3.17
 MAINTAINER Marc Crebassa <aalaesar@gmail.com>
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,4 +1,4 @@
-FROM alpine:3.16 as qemu
+FROM alpine:3.17 as qemu
 
 ARG QEMU_VERSION=4.2.0-6
 ARG QEMU_ARCHS="ppc64le"
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM ppc64le/golang:1.18.9-alpine3.17
+FROM ppc64le/golang:1.19.5-alpine3.17
 MAINTAINER David Wilder <wilder@ibm.com>
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,4 +1,4 @@
-FROM alpine:3.16 as qemu
+FROM alpine:3.17 as qemu
 
 ARG QEMU_VERSION=6.1.0-8
 ARG QEMU_ARCHS="s390x"
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM s390x/golang:1.18.9-alpine3.17
+FROM s390x/golang:1.19.5-alpine3.17
 MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind cleanup

1 add go version to other architectures .
2 change the base image alpine to 3.17.

fix #417 