### PR TITLE
Auto-update golang to latest 1.19 

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -3,7 +3,7 @@ FROM calico/bpftool:v5.3-amd64 as bpftool
 FROM us-docker.pkg.dev/google.com/api-project-999119582588/go-boringcrypto/golang:1.18.10b7
 MAINTAINER Shaun Crampton <shaun@projectcalico.org>
 
-ARG GO_VERSION=1.19.6
+ARG GO_VERSION
 ARG QEMU_VERSION=4.2.0-6
 
 # we need these two distinct lists. The first one is the names used by the qemu distributions
@@ -46,7 +46,7 @@ RUN echo 'APT::Default-Release "buster";' > /etc/apt/apt.conf.d/99defaultrelease
 
 RUN rm /etc/apt/sources.list.d/buster-backports.list
 
-RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz
+RUN wget https://go.dev/dl/${GO_VERSION}.linux-amd64.tar.gz
 RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
 RUN rm go${GO_VERSION}.linux-amd64.tar.gz
 RUN wget https://apt.llvm.org/llvm.sh

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -3,7 +3,7 @@ FROM calico/bpftool:v5.3-amd64 as bpftool
 FROM us-docker.pkg.dev/google.com/api-project-999119582588/go-boringcrypto/golang:1.18.9b7
 MAINTAINER Shaun Crampton <shaun@projectcalico.org>
 
-ARG GO_VERSION=1.19.5
+ARG GO_VERSION=1.19.6
 ARG QEMU_VERSION=4.2.0-6
 
 # we need these two distinct lists. The first one is the names used by the qemu distributions

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -47,8 +47,8 @@ RUN echo 'APT::Default-Release "buster";' > /etc/apt/apt.conf.d/99defaultrelease
 RUN rm /etc/apt/sources.list.d/buster-backports.list
 
 RUN wget https://go.dev/dl/${GO_VERSION}.linux-amd64.tar.gz
-RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
-RUN rm go${GO_VERSION}.linux-amd64.tar.gz
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf ${GO_VERSION}.linux-amd64.tar.gz
+RUN rm ${GO_VERSION}.linux-amd64.tar.gz
 RUN wget https://apt.llvm.org/llvm.sh
 RUN bash ./llvm.sh 12
 RUN apt install clang-12

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,6 +1,6 @@
 FROM calico/bpftool:v5.3-amd64 as bpftool
 
-FROM us-docker.pkg.dev/google.com/api-project-999119582588/go-boringcrypto/golang:1.18.9b7
+FROM us-docker.pkg.dev/google.com/api-project-999119582588/go-boringcrypto/golang:1.18.10b7
 MAINTAINER Shaun Crampton <shaun@projectcalico.org>
 
 ARG GO_VERSION=1.19.6

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -12,7 +12,7 @@ RUN apt update && apt install -y curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm64v8/golang:1.19.6-buster
+FROM arm64v8/golang:1.19-buster
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -12,7 +12,7 @@ RUN apt update && apt install -y curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm64v8/golang:1.19.5-buster
+FROM arm64v8/golang:1.19.6-buster
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2
 

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm32v7/golang:1.19.5-alpine3.17
+FROM arm32v7/golang:1.19.6-alpine3.17
 MAINTAINER Marc Crebassa <aalaesar@gmail.com>
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm32v7/golang:1.19.6-alpine3.17
+FROM arm32v7/golang:1.19-alpine
 MAINTAINER Marc Crebassa <aalaesar@gmail.com>
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM arm32v7/golang:1.19.6-alpine3.17
+FROM arm32v7/golang:1.19.5-alpine3.17
 MAINTAINER Marc Crebassa <aalaesar@gmail.com>
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM ppc64le/golang:1.19.6-alpine3.17
+FROM ppc64le/golang:1.19-alpine
 MAINTAINER David Wilder <wilder@ibm.com>
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM ppc64le/golang:1.19.5-alpine3.17
+FROM ppc64le/golang:1.19.6-alpine3.17
 MAINTAINER David Wilder <wilder@ibm.com>
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM s390x/golang:1.19.6-alpine3.17
+FROM s390x/golang:1.19-alpine
 MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN for i in ${QEMU_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
 RUN chmod +x /usr/bin/qemu-*
 
-FROM s390x/golang:1.19.5-alpine3.17
+FROM s390x/golang:1.19.6-alpine3.17
 MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
 
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Makefile
+++ b/Makefile
@@ -60,14 +60,14 @@ join_platforms = $(subst $(space),$(comma),$(call prefix_linux,$(strip $1)))
 # Check if the docker daemon is running in experimental mode (to get the --squash flag)
 DOCKER_EXPERIMENTAL=$(shell docker version -f '{{ .Server.Experimental }}')
 DOCKER_BUILD_ARGS?=
+# This script will get the latest patch version in (latest-1) minor version
+GO_VERSION:=$(shell curl -s https://go.dev/dl/?mode=json | jq -r '.[1].version')
+DOCKER_BUILD_ARGS+=--build-arg GO_VERSION=$(GO_VERSION)
 ifeq ($(DOCKER_EXPERIMENTAL),true)
 DOCKER_BUILD_ARGS+=--squash
 endif
-ifneq ($(ARCH),amd64)\
-#This script will get the latest patch version in (latest-1) minor version
-GO_VERSION=$(curl -s https://go.dev/dl/?mode=json | jq -r '.[1].version')
+ifneq ($(ARCH),amd64)
 DOCKER_BUILD_ARGS+=--cpuset-cpus 0
-DOCKER_BUILD_ARGS+=$(GO_VERSION)
 endif
 
 ###############################################################################

--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,9 @@ DOCKER_BUILD_ARGS+=--squash
 endif
 ifneq ($(ARCH),amd64)\
 #This script will get the latest patch version in (latest-1) minor version
-GO_VERSION=$(curl -s https://go.dev/dl/?mode=json | jq -r '.[0].version')
+GO_VERSION=$(curl -s https://go.dev/dl/?mode=json | jq -r '.[1].version')
 DOCKER_BUILD_ARGS+=--cpuset-cpus 0
-DOCKER_BUILD_ARGS+=GO_VERSION
+DOCKER_BUILD_ARGS+=$(GO_VERSION)
 endif
 
 ###############################################################################

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,11 @@ DOCKER_BUILD_ARGS?=
 ifeq ($(DOCKER_EXPERIMENTAL),true)
 DOCKER_BUILD_ARGS+=--squash
 endif
-ifneq ($(ARCH),amd64)
+ifneq ($(ARCH),amd64)\
+#This script will get the latest patch version in (latest-1) minor version
+GO_VERSION=$(curl -s https://go.dev/dl/?mode=json | jq -r '.[0].version')
 DOCKER_BUILD_ARGS+=--cpuset-cpus 0
+DOCKER_BUILD_ARGS+=GO_VERSION
 endif
 
 ###############################################################################


### PR DESCRIPTION
This PR will always use the (latest-1) minor version's latest patch. For example, now it would use the golang 1.19.6.
The only downside is that when golang 1.21 is out we have to fix it on the latest 1.19 and create a new branch then. I think this is much better than creating a branch with every patch release. 

