### PR TITLE
add go binary gotestyourself/gotestsum

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -111,6 +111,7 @@ RUN \
   go install k8s.io/code-generator/cmd/defaulter-gen@v0.24.0 && \
   go install k8s.io/code-generator/cmd/conversion-gen@v0.24.0 && \
   go install github.com/swaggo/swag/cmd/swag@v1.8.7 && \
+  go install gotest.tools/gotestsum@latest && \
   rm -rf /go/src/* /root/.cache
 
 # Install ginkgo v2 as ginkgo2 and keep ginkgo v1 as ginkgo

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -105,6 +105,7 @@ RUN \
   go install k8s.io/code-generator/cmd/openapi-gen@v0.24.0 && \
   go install k8s.io/code-generator/cmd/deepcopy-gen@v0.24.0 && \
   go install github.com/swaggo/swag/cmd/swag@v1.8.7 && \
+  go install gotest.tools/gotestsum@latest && \
   rm -rf /go/src/* /root/.cache
 
 # Ensure that everything under the GOPATH is writable by everyone


### PR DESCRIPTION
[GoTestSum](https://github.com/gotestyourself/gotestsum) runs tests using `go test -json`, prints formatted test output, and a summary of the test run. It is designed to work well for both local development, and for automation like CI.

I've recently found this useful as a helper to integrate with our current CI to make the tests visually organised.

Bonus: no more `set -o pipefail` hacks just to get junit exporters working