### PR TITLE
Upgrade golangci-lint to v1.52.2

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -86,7 +86,7 @@ RUN cp -a $GOROOT $GOCGO && \
   go install -v std && \
   rm -rf /go/src/* /root/.cache
 
-ENV GO_LINT_VERSION=v1.50.1
+ENV GO_LINT_VERSION=v1.52.2
 
 # Install go programs that we rely on
 RUN \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -89,7 +89,7 @@ RUN cp -a $GOROOT $GOCGO && \
   go install -v std && \
   rm -rf /go/src/* /root/.cache
 
-ENV GO_LINT_VERSION=v1.50.1
+ENV GO_LINT_VERSION=v1.52.2
 
 # Install go programs that we rely on
 RUN \

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -47,7 +47,7 @@ RUN go install -v std
 RUN go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 
 # Install linting tools
-ENV GO_LINT_VERSION=v1.50.1
+ENV GO_LINT_VERSION=v1.52.2
 RUN \
   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GO_LINT_VERSION && \
   golangci-lint --version

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -47,7 +47,7 @@ RUN go install -v std
 RUN go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 
 # Install linting tools
-ENV GO_LINT_VERSION=v1.50.1
+ENV GO_LINT_VERSION=v1.52.2
 RUN \
   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GO_LINT_VERSION && \
   golangci-lint --version

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -47,7 +47,7 @@ RUN go install -v std
 RUN go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 
 # Install linting tools
-ENV GO_LINT_VERSION=v1.50.1
+ENV GO_LINT_VERSION=v1.52.2
 RUN \
   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GO_LINT_VERSION && \
   golangci-lint --version


### PR DESCRIPTION
This fixes golangci-lint 1.50.x excessive memory usage with golang 1.20.

Upstream issue: https://github.com/golangci/golangci-lint/issues/3565.