### PR TITLE
Make Tests stage depend on Push manifest stage

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: go-build
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 execution_time_limit:
   minutes: 60
@@ -17,68 +17,64 @@ global_job_config:
       - checkout
       # Semaphore is doing shallow clone on a commit without tags.
       # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always) @ Makefile.common
-      - git fetch --unshallow
+      - retry git fetch --unshallow
 
 blocks:
-# Run the full set of tests. Each job can potentially be run in parallel,
-# provided Semaphore has enough boxes available.
-- name: "Tests"
-  dependencies: ["Build images"]
-# TODO re enable this when semaphore has provided an explanation as to why it's timing out.
-#  run:
-#    when: "change_in('/Makefile.common') or change_in('/.semaphore/')"
-  task:
-    jobs:
-    - name: "Build downstream projects with our Makefile.common"
-      commands:
-      - git clone git@github.com:projectcalico/calico.git calico
-      - cd calico
-      - git checkout "${CALICO_BRANCH}"
-      - perl -0777 -pi -e's/GO_BUILD_VER\s*[?:]?=\s*\K[\.0-9a-z]+/'"${SEMAPHORE_GIT_BRANCH}"'/' metadata.mk
-      - cd $PROJECT
-      - make ut
-      env_vars:
-        # The branch to test the current go-build against
-        - name: CALICO_BRANCH
-          value: master
-      matrix:
-      - env_var: PROJECT
-        values: ["felix", "calicoctl", "libcalico-go"]
+  - name: "Build images"
+    dependencies: []
+    task:
+      secrets:
+        - name: quay-robot-calico-and-semaphoreci
+        - name: docker
+      jobs:
+        - name: Build and push image
+          commands:
+            - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
+            - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
+            - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
+            - export VERSION=$BRANCH_NAME
+            - make image ARCH=$ARCH
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make push ARCH=$ARCH CONFIRM=true; fi
+          matrix:
+            - env_var: ARCH
+              values: ["amd64", "arm64", "armv7", "ppc64le", "s390x"]
 
-- name: "Build images"
-  dependencies: []
-  task:
-    secrets:
-    - name: quay-robot-calico-and-semaphoreci
-    - name: docker
-    jobs:
-    - name: Build and push image
-      commands:
-      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
-      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
-      - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
-      - export VERSION=$BRANCH_NAME
-      - make image ARCH=$ARCH
-      - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make push ARCH=$ARCH CONFIRM=true; fi
-      matrix:
-      - env_var: ARCH
-        values: ["amd64", "arm64","armv7", "ppc64le", "s390x"]
+  - name: "Push manifest"
+    dependencies: ["Build images"]
+    task:
+      secrets:
+        - name: quay-robot-calico-and-semaphoreci
+        - name: docker
+      jobs:
+        - name: Push multi-arch manifest
+          commands:
+            - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
+            - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
+            - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
+            - export VERSION=$BRANCH_NAME
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make push-manifest CONFIRM=true; fi
 
-- name: "Push manifest"
-  skip:
-    # Only run on branches, not PRs.
-    when: "branch !~ '.+'"
-  dependencies: ["Build images"]
-  task:
-    secrets:
-    - name: quay-robot-calico-and-semaphoreci
-    - name: docker
-    jobs:
-    - name: Push multi-arch manifest
-      commands:
-      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
-      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
-      - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
-      - export VERSION=$BRANCH_NAME
-      - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make push-manifest CONFIRM=true; fi
-
+  # Run the full set of tests. Each job can potentially be run in parallel,
+  # provided Semaphore has enough boxes available.
+  - name: "Tests"
+    dependencies: ["Push manifest"]
+    # TODO re enable this when semaphore has provided an explanation as to why it's timing out.
+    #  run:
+    #    when: "change_in('/Makefile.common') or change_in('/.semaphore/')"
+    task:
+      jobs:
+        - name: "Build downstream projects with our Makefile.common"
+          commands:
+            - retry git clone git@github.com:projectcalico/calico.git calico
+            - cd calico
+            - git checkout "${CALICO_BRANCH}"
+            - perl -0777 -pi -e's/GO_BUILD_VER\s*[?:]?=\s*\K[\.0-9a-z]+/'"${SEMAPHORE_GIT_BRANCH}"'/' metadata.mk
+            - cd $PROJECT
+            - make ut
+          env_vars:
+            # The branch to test the current go-build against
+            - name: CALICO_BRANCH
+              value: master
+          matrix:
+            - env_var: PROJECT
+              values: ["felix", "calicoctl", "libcalico-go"]


### PR DESCRIPTION
This changeset makes "Tests" task depends on the "Push manifest" task. Calico uses multi-arch manifests in builds [1] but go-build doesn't push multi-arch manifests consistently.

When we build new changes in the main branch or a PR, the "Push manifest" task is running in parallel with "Tests" task. The "Tests" task will likely to fail because dockerhub doesn't have the manifests yet.

For an existing branch, like release branches v0.xy, new changes in branch won't recreate the manifests. This results different hashes for `calico/go-build:v0.xy` (older image) and `calico/go-build:v0.xy-arch` (newer image).

[1] https://github.com/projectcalico/calico/blob/master/lib.Makefile#L150