### PR TITLE
Upgrade k8s to v1.26 and golang x/tools to v0.8.0

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -5,7 +5,7 @@ FROM golang:1.20.3-buster
 LABEL maintainer="Shaun Crampton <shaun@projectcalico.org>"
 
 ARG GO_LINT_VERSION=v1.52.2
-ARG K8S_VERSION=v1.25.8
+ARG K8S_VERSION=v1.26.3
 ARG LLVM_VERSION=12
 ARG MANIFEST_TOOL_VERSION=v1.0.2
 ARG MOCKERY_VER=2.14.0
@@ -69,20 +69,20 @@ RUN \
     go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.2 && \
         mv /go/bin/ginkgo /go/bin/ginkgo2 && \
     go install github.com/onsi/ginkgo/ginkgo@v1.16.5 && \
-    go install golang.org/x/tools/cmd/goimports@v0.1.10 && \
+    go install golang.org/x/tools/cmd/goimports@v0.8.0 && \
     curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GO_LINT_VERSION && \
     go install github.com/pmezard/licenses@master && \
     go install github.com/wadey/gocovmerge@master && \
     go install github.com/mikefarah/yq/v3@3.4.1 && \
     go install github.com/jstemmer/go-junit-report@v1.0.0 && \
-    go install golang.org/x/tools/cmd/stringer@v0.1.10 && \
-    go install k8s.io/code-generator/cmd/openapi-gen@v0.25.8 && \
-    go install k8s.io/code-generator/cmd/deepcopy-gen@v0.25.8 && \
-    go install k8s.io/code-generator/cmd/client-gen@v0.25.8 && \
-    go install k8s.io/code-generator/cmd/lister-gen@v0.25.8 && \
-    go install k8s.io/code-generator/cmd/informer-gen@v0.25.8 && \
-    go install k8s.io/code-generator/cmd/defaulter-gen@v0.25.8 && \
-    go install k8s.io/code-generator/cmd/conversion-gen@v0.25.8 && \
+    go install golang.org/x/tools/cmd/stringer@v0.8.0 && \
+    go install k8s.io/code-generator/cmd/openapi-gen@v0.26.3 && \
+    go install k8s.io/code-generator/cmd/deepcopy-gen@v0.26.3 && \
+    go install k8s.io/code-generator/cmd/client-gen@v0.26.3 && \
+    go install k8s.io/code-generator/cmd/lister-gen@v0.26.3 && \
+    go install k8s.io/code-generator/cmd/informer-gen@v0.26.3 && \
+    go install k8s.io/code-generator/cmd/defaulter-gen@v0.26.3 && \
+    go install k8s.io/code-generator/cmd/conversion-gen@v0.26.3 && \
     go install github.com/swaggo/swag/cmd/swag@v1.8.7 && \
     go install gotest.tools/gotestsum@latest && \
     go clean -modcache && go clean -cache

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -14,7 +14,7 @@ RUN curl -sfL https://github.com/multiarch/qemu-user-static/releases/download/v$
 FROM arm64v8/golang:1.20.3-buster
 
 ARG GO_LINT_VERSION=v1.52.2
-ARG K8S_VERSION=v1.25.8
+ARG K8S_VERSION=v1.26.3
 ARG LLVM_VERSION=12
 ARG MANIFEST_TOOL_VERSION=v1.0.2
 ARG MOCKERY_VER=2.14.0
@@ -73,15 +73,15 @@ RUN \
     go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.2 && \
         mv /go/bin/ginkgo /go/bin/ginkgo2 && \
     go install github.com/onsi/ginkgo/ginkgo@v1.16.5 && \
-    go install golang.org/x/tools/cmd/goimports@v0.1.10 && \
+    go install golang.org/x/tools/cmd/goimports@v0.8.0 && \
     curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GO_LINT_VERSION && \
     go install github.com/pmezard/licenses@master && \
     go install github.com/wadey/gocovmerge@master && \
     go install github.com/mikefarah/yq/v3@3.4.1 && \
     go install github.com/jstemmer/go-junit-report@v1.0.0 && \
-    go install golang.org/x/tools/cmd/stringer@v0.1.10 && \
-    go install k8s.io/code-generator/cmd/openapi-gen@v0.25.8 && \
-    go install k8s.io/code-generator/cmd/deepcopy-gen@v0.25.8 && \
+    go install golang.org/x/tools/cmd/stringer@v0.8.0 && \
+    go install k8s.io/code-generator/cmd/openapi-gen@v0.26.3 && \
+    go install k8s.io/code-generator/cmd/deepcopy-gen@v0.26.3 && \
     go install github.com/swaggo/swag/cmd/swag@v1.8.7 && \
     go install gotest.tools/gotestsum@latest && \
     go clean -modcache && go clean -cache

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -12,7 +12,7 @@ FROM arm32v7/golang:1.20.3-alpine3.17
 LABEL maintainer="Marc Crebassa <aalaesar@gmail.com>"
 
 ARG GO_LINT_VERSION=v1.52.2
-ARG K8S_VERSION=v1.25.8
+ARG K8S_VERSION=v1.26.3
 ARG MANIFEST_TOOL_VERSION=v1.0.2
 
 # Enable non-native builds of this image on an amd64 hosts.

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -12,7 +12,7 @@ FROM ppc64le/golang:1.20.3-alpine3.17
 LABEL maintainer="David Wilder <wilder@ibm.com>"
 
 ARG GO_LINT_VERSION=v1.52.2
-ARG K8S_VERSION=v1.25.8
+ARG K8S_VERSION=v1.26.3
 ARG MANIFEST_TOOL_VERSION=v1.0.2
 
 # Enable non-native builds of this image on an amd64 hosts.

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -12,7 +12,7 @@ FROM s390x/golang:1.20.3-alpine3.17
 LABEL maintainer="LoZ Open SourceEcosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)"
 
 ARG GO_LINT_VERSION=v1.52.2
-ARG K8S_VERSION=v1.25.8
+ARG K8S_VERSION=v1.26.3
 ARG MANIFEST_TOOL_VERSION=v1.0.2
 
 # Enable non-native builds of this image on an amd64 hosts.


### PR DESCRIPTION
This changeset upgrades k8s to v1.26 and golang x/tools to v0.8.0 to match latest versions used in Calico OSS and Enterprise. Without the golang x/tools update, felix bpf stringer code generator fails with internal error using golang 1.20.