### PR TITLE
calico/go-build s390x image on Dockerhub seems to be missing tools for testing

### DIFF
--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,25 +1,28 @@
-FROM alpine:3.17 as qemu
+FROM calico/bpftool:v5.3-s390x as bpftool
+
+FROM debian:buster as qemu
+
+LABEL maintainer="IBM Z Open Source Ecosystem (https://community.ibm.com/community/user/ibmz-and-linuxone/groups/topic-home?CommunityKey=64d1d1bd-66bc-4ecb-b9e8-0372b18c5bcb)"
 
 ARG QEMU_VERSION=7.2.0-1
 
-RUN apk --update add curl
+RUN apt update && apt install -y curl
 
-# Enable non-native runs on amd64 architecture hosts
 RUN curl -sfL https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-s390x-static.tar.gz | tar xz -C /usr/bin
 
-FROM s390x/golang:1.20.4-alpine3.17
-
-LABEL maintainer="LoZ Open SourceEcosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)"
+FROM s390x/golang:1.19-buster
 
 ARG GO_LINT_VERSION=v1.52.2
 ARG K8S_VERSION=v1.26.3
+ARG LLVM_VERSION=12
 ARG MANIFEST_TOOL_VERSION=v1.0.2
+ARG MOCKERY_VER=2.14.0
+ARG SU_EXEC_VER=212b75144bbc06722fbd7661f651390dc47a43d1
 
 # Enable non-native builds of this image on an amd64 hosts.
 # This must be the first RUN command in this file!
 COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 
-# Install su-exec for use in the entrypoint.sh (so processes run as the right user)
 # Install bash for the entry script (and because it's generally useful)
 # Install curl
 # Install git for fetching Go dependencies
@@ -28,46 +31,59 @@ COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 # Install make for building things
 # Install util-linux for column command (used for output formatting).
 # Install grep, sed, zip, and jq for use in some Makefiles
-# Install shadow for useradd (it allows to use big UID)
-RUN apk update && apk add --no-cache su-exec curl bash git openssh make wget util-linux tini file grep sed jq zip shadow libpcap-dev
-RUN apk upgrade --no-cache
+# Install gcc for cgo.
+# Install lsb-release software-properties-common for llvm upgrade script
+# Install clang, libbpf and newer kernel headers for building BPF binaries.
+RUN echo 'APT::Default-Release "buster";' > /etc/apt/apt.conf.d/99defaultrelease && \
+    echo 'deb     http://ftp.am.debian.org/debian/    buster-backports main contrib non-free' > /etc/apt/sources.list.d/buster-backports.list && \
+    apt-get -y -o Acquire::Check-Valid-Until=false update &&  \
+    apt-get -y upgrade && \
+    apt-get install --no-install-recommends -y -t buster-backports \
+        libbpf-dev linux-headers-s390x && \
+    apt-get install --no-install-recommends -y \
+        curl git openssh-client make wget util-linux file grep sed jq zip \
+        lsb-release software-properties-common binutils iproute2 \
+        ca-certificates gcc libc-dev bsdmainutils strace libpcap-dev
+
+RUN curl -sfL https://apt.llvm.org/llvm.sh | bash -s -- ${LLVM_VERSION} && \
+    apt-get install clang-${LLVM_VERSION}
+
+RUN apt-get autoclean && apt-get clean && \
+    rm /etc/apt/sources.list.d/buster-backports.list
+
+# su-exec is used by the entrypoint script to execute the user's command with the right UID/GID.
+# (sudo doesn't work easily in a container.)  The version was current master at the time of writing.
+RUN  set -ex; \
+    curl -o /sbin/su-exec.c https://raw.githubusercontent.com/ncopa/su-exec/${SU_EXEC_VER}/su-exec.c; \
+    gcc -Wall /sbin/su-exec.c -o/sbin/su-exec; \
+    chown root:root /sbin/su-exec; \
+    chmod 0755 /sbin/su-exec; \
+    rm /sbin/su-exec.c
+
+RUN go install github.com/vektra/mockery/v2@latest
 
 # Disable ssh host key checking
 RUN echo 'Host *' >> /etc/ssh/ssh_config \
   && echo '    StrictHostKeyChecking no' >> /etc/ssh/ssh_config
 
-# Install ginkgo CLI tool for running tests
+# Install go programs that we rely on
 # Install ginkgo v2 as ginkgo2 and keep ginkgo v1 as ginkgo
-RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.2 && \
-    mv /go/bin/ginkgo /go/bin/ginkgo2 && \
-  go install github.com/onsi/ginkgo/ginkgo@v1.16.5
-
-# Install linting tools
-RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GO_LINT_VERSION
-
-# Install license checking tool.
-RUN go install github.com/pmezard/licenses@master
-
-# Install tool to merge coverage reports.
-RUN go install github.com/wadey/gocovmerge@master
-
-# Install CLI tool for working with yaml files
-RUN go install github.com/mikefarah/yq/v3@3.4.1
-
-# Delete all the Go sources that were downloaded, we only rely on the binaries
-RUN rm -rf /go/src/*
-
-# Install generation tools.
-RUN  go install k8s.io/code-generator/cmd/openapi-gen@master
-RUN  go install k8s.io/code-generator/cmd/deepcopy-gen@master
-
-# Install Swaggo
-RUN go install github.com/swaggo/swag/cmd/swag@v1.8.7
-
-# Install necessary Kubernetes binaries used in tests.
-RUN wget https://dl.k8s.io/${K8S_VERSION}/bin/linux/s390x/kube-apiserver -O /usr/local/bin/kube-apiserver && chmod +x /usr/local/bin/kube-apiserver && \
-	wget https://dl.k8s.io/release/${K8S_VERSION}/bin/linux/s390x/kubectl -O /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl && \
-	wget https://dl.k8s.io/${K8S_VERSION}/bin/linux/s390x/kube-controller-manager -O /usr/local/bin/kube-controller-manager && chmod +x /usr/local/bin/kube-controller-manager
+RUN \
+    go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.2 && \
+        mv /go/bin/ginkgo /go/bin/ginkgo2 && \
+    go install github.com/onsi/ginkgo/ginkgo@v1.16.5 && \
+    go install golang.org/x/tools/cmd/goimports@v0.8.0 && \
+    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GO_LINT_VERSION && \
+    go install github.com/pmezard/licenses@master && \
+    go install github.com/wadey/gocovmerge@master && \
+    go install github.com/mikefarah/yq/v3@3.4.1 && \
+    go install github.com/jstemmer/go-junit-report@v1.0.0 && \
+    go install golang.org/x/tools/cmd/stringer@v0.8.0 && \
+    go install k8s.io/code-generator/cmd/openapi-gen@v0.26.3 && \
+    go install k8s.io/code-generator/cmd/deepcopy-gen@v0.26.3 && \
+    go install github.com/swaggo/swag/cmd/swag@v1.8.7 && \
+    go install gotest.tools/gotestsum@latest && \
+    go clean -modcache && go clean -cache
 
 # Ensure that everything under the GOPATH is writable by everyone
 RUN chmod -R 777 $GOPATH
@@ -75,5 +91,16 @@ RUN chmod -R 777 $GOPATH
 RUN curl -sfL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-s390x -o /usr/bin/manifest-tool && \
     chmod +x /usr/bin/manifest-tool
 
+# crane is needed for our release targets to copy images from the dev registries to the release registries.
+RUN curl -sfL https://github.com/google/go-containerregistry/releases/download/v0.14.0/go-containerregistry_Linux_s390x.tar.gz | tar xz -C /usr/bin crane
+
+# Install necessary Kubernetes binaries used in tests.
+RUN wget https://dl.k8s.io/${K8S_VERSION}/bin/linux/s390x/kube-apiserver -O /usr/local/bin/kube-apiserver && chmod +x /usr/local/bin/kube-apiserver && \
+    wget https://dl.k8s.io/release/${K8S_VERSION}/bin/linux/s390x/kubectl -O /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl && \
+    wget https://dl.k8s.io/${K8S_VERSION}/bin/linux/s390x/kube-controller-manager -O /usr/local/bin/kube-controller-manager && chmod +x /usr/local/bin/kube-controller-manager
+
+# Add bpftool for Felix UT/FV.
+COPY --from=bpftool /bpftool /usr/bin
+
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
While running Calico testcases on `s390x` arch it is observed that `calico/go-build:v0.85-s390x` does not contain few components when compared to `amd64`. This is also evident in the image files sizes for `s390x` (498.06MB) and `amd64` (1.08 GB).

This PR attempts to bring `s390x` image closer to `amd64`.

Since `Dockerfile.s390x` changes implemented by this PR require correct `calico/bpftool:v5.3-s390x` image, this issue must be also be addressed first: https://github.com/projectcalico/calico/issues/7654

Thanks.