### PR TITLE
Fix the ut's that don't work before an image is pushed.

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -20,37 +20,17 @@ global_job_config:
       - git fetch --unshallow
 
 blocks:
-# Run the full set of tests. Each job can potentially be run in parallel,
-# provided Semaphore has enough boxes available.
-- name: "Tests"
-  dependencies: ["Build images"]
-# TODO re enable this when semaphore has provided an explanation as to why it's timing out.
-#  run:
-#    when: "change_in('/Makefile.common') or change_in('/.semaphore/')"
-  task:
-    jobs:
-    - name: "Build downstream projects with our Makefile.common"
-      commands:
-      - git clone git@github.com:projectcalico/calico.git calico
-      - cd calico
-      - git checkout "${CALICO_BRANCH}"
-      - perl -0777 -pi -e's/GO_BUILD_VER\s*[?:]?=\s*\K[\.0-9a-z]+/'"${SEMAPHORE_GIT_BRANCH}"'/' metadata.mk
-      - cd $PROJECT
-      - make ut
-      env_vars:
-        # The branch to test the current go-build against
-        - name: CALICO_BRANCH
-          value: master
-      matrix:
-      - env_var: PROJECT
-        values: ["felix", "calicoctl", "libcalico-go"]
 
-- name: "Build images"
+- name: "Build images and run ut"
   dependencies: []
   task:
     secrets:
     - name: quay-robot-calico-and-semaphoreci
     - name: docker
+    env_vars:
+      # The branch to test the current go-build against
+      - name: CALICO_BRANCH
+        value: master
     jobs:
     - name: Build and push image
       commands:
@@ -60,6 +40,11 @@ blocks:
       - export VERSION=$BRANCH_NAME
       - make image ARCH=$TARGET_ARCH
       - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make push ARCH=$TARGET_ARCH CONFIRM=true; fi
+      - git clone git@github.com:projectcalico/calico.git calico
+      - cd calico
+      - git checkout "${CALICO_BRANCH}"
+      - perl -0777 -pi -e's/GO_BUILD_VER\s*[?:]?=\s*\K[\.0-9a-z]+/'"${SEMAPHORE_GIT_BRANCH}-${TARGET_ARCH}"'/' metadata.mk
+      - if [ "${TARGET_ARCH}" == "amd64" ]; then cd felix && make ut && cd ../calicoctl && make ut && cd ../libcalico-go && make ut; fi
       matrix:
       - env_var: TARGET_ARCH
         values: ["amd64", "arm64","armv7", "ppc64le", "s390x"]
@@ -68,7 +53,7 @@ blocks:
   skip:
     # Only run on branches, not PRs.
     when: "branch !~ '.+'"
-  dependencies: ["Build images"]
+  dependencies: ["Build images and run ut"]
   task:
     secrets:
     - name: quay-robot-calico-and-semaphoreci


### PR DESCRIPTION
Existing situation:
- When someone pushes a branch directly (or when a PR is merged) to https://github.com/projectcalico/go-build, CI/CD will run that pushes images.
- When someone forks this repo and creates a PR, the CI that runs will not push images.

The above is good and all, but it becomes problematic when the UT suite is dependent on images being pushed. Therefore the UTs are completely broken for any outside contributor who does not have the right privileges or connections to get images pushed.

This PR runs the UT suite directly after the amd64 image is built and removes the UT block. Other options explored:
- Building images again inside the UT. I found this a bit wasteful
- Caching images in sem is not an option, since the images are so large.
