### PR TITLE
Install ping utility for bullseye

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -31,7 +31,7 @@ RUN apt-get -y update && apt-get -y upgrade && \
     apt-get install --no-install-recommends -y \
         libbpf-dev linux-headers-amd64 \
         curl git openssh-client make wget util-linux file grep sed jq zip \
-        lsb-release software-properties-common binutils iproute2 \
+        lsb-release software-properties-common binutils inetutils-ping iproute2 \
         ca-certificates gcc mingw-w64 libc-dev bsdmainutils strace libpcap-dev \
         autoconf automake build-essential \
         libcurl4-openssl-dev libgeoip-dev liblmdb-dev \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get -y upgrade && \
     apt-get install --no-install-recommends -y \
         libbpf-dev linux-headers-arm64 \
         curl git openssh-client make wget util-linux file grep sed jq zip \
-        lsb-release software-properties-common binutils iproute2 \
+        lsb-release software-properties-common binutils inetutils-ping iproute2 \
         ca-certificates gcc libc-dev bsdmainutils strace libpcap-dev
 
 RUN curl -sfL https://apt.llvm.org/llvm.sh | bash -s -- ${LLVM_VERSION} && \


### PR DESCRIPTION
The ping utility doesn't seem to be installed by default in debian bullseye. This fails egress-gateway UTs which depend on ping to exist in the system search path.