### PR TITLE
Update golang to 1.20.8 to fix CVEs

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,6 +1,6 @@
 FROM calico/bpftool:v5.3-amd64 as bpftool
 
-FROM golang:1.20.6-bullseye
+FROM golang:1.20.8-bullseye
 
 LABEL maintainer="Shaun Crampton <shaun@projectcalico.org>"
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -11,7 +11,7 @@ RUN apt update && apt install -y curl
 # Enable non-native runs on amd64 architecture hosts
 RUN curl -sfL https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-aarch64-static.tar.gz | tar xz -C /usr/bin
 
-FROM arm64v8/golang:1.20.6-bullseye
+FROM arm64v8/golang:1.20.8-bullseye
 
 
 ARG GO_LINT_VERSION=v1.52.2

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -7,7 +7,7 @@ RUN apk --update add curl
 # Enable non-native runs on amd64 architecture hosts
 RUN curl -sfL https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-arm-static.tar.gz | tar xz -C /usr/bin
 
-FROM arm32v7/golang:1.20.6-alpine3.18
+FROM arm32v7/golang:1.20.8-alpine3.18
 
 LABEL maintainer="Marc Crebassa <aalaesar@gmail.com>"
 

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -7,7 +7,7 @@ RUN apk --update add curl
 # Enable non-native runs on amd64 architecture hosts
 RUN curl -sfL https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-ppc64le-static.tar.gz | tar xz -C /usr/bin
 
-FROM ppc64le/golang:1.20.6-alpine3.18
+FROM ppc64le/golang:1.20.8-alpine3.18
 
 LABEL maintainer="David Wilder <wilder@ibm.com>"
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -7,7 +7,7 @@ RUN apk --update add curl
 # Enable non-native runs on amd64 architecture hosts
 RUN curl -sfL https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-s390x-static.tar.gz | tar xz -C /usr/bin
 
-FROM s390x/golang:1.20.6-alpine3.18
+FROM s390x/golang:1.20.8-alpine3.18
 
 LABEL maintainer="LoZ Open SourceEcosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)"
 


### PR DESCRIPTION
Fixes 

```
CVE-2023-29406
CVE-2023-2727
CVE-2023-39533
CVE-2023-2728
CVE-2023-29409
```

