### PR TITLE
[v0.89] Auto pick #475: Update golangci-lint to v1.54.2 for compatibility with golang

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -4,7 +4,7 @@ FROM golang:1.21.1-bullseye
 
 LABEL maintainer="Shaun Crampton <shaun@projectcalico.org>"
 
-ARG GO_LINT_VERSION=v1.52.2
+ARG GO_LINT_VERSION=v1.54.2
 ARG K8S_VERSION=v1.26.3
 ARG LLVM_VERSION=15
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -13,7 +13,7 @@ RUN curl -sfL https://github.com/multiarch/qemu-user-static/releases/download/v$
 
 FROM arm64v8/golang:1.21.1-bullseye
 
-ARG GO_LINT_VERSION=v1.52.2
+ARG GO_LINT_VERSION=v1.54.2
 ARG K8S_VERSION=v1.26.3
 ARG LLVM_VERSION=15
 ARG MANIFEST_TOOL_VERSION=v1.0.2

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -11,7 +11,7 @@ FROM arm32v7/golang:1.21.1-alpine3.18
 
 LABEL maintainer="Marc Crebassa <aalaesar@gmail.com>"
 
-ARG GO_LINT_VERSION=v1.52.2
+ARG GO_LINT_VERSION=v1.54.2
 ARG K8S_VERSION=v1.26.3
 ARG MANIFEST_TOOL_VERSION=v1.0.2
 

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -11,7 +11,7 @@ FROM ppc64le/golang:1.21.1-alpine3.18
 
 LABEL maintainer="David Wilder <wilder@ibm.com>"
 
-ARG GO_LINT_VERSION=v1.52.2
+ARG GO_LINT_VERSION=v1.54.2
 ARG K8S_VERSION=v1.26.3
 ARG MANIFEST_TOOL_VERSION=v1.0.2
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -11,7 +11,7 @@ FROM s390x/golang:1.21.1-alpine3.18
 
 LABEL maintainer="LoZ Open SourceEcosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)"
 
-ARG GO_LINT_VERSION=v1.52.2
+ARG GO_LINT_VERSION=v1.54.2
 ARG K8S_VERSION=v1.26.3
 ARG MANIFEST_TOOL_VERSION=v1.0.2
 


### PR DESCRIPTION
Cherry pick of #475 on v0.89.

#475: Update golangci-lint to v1.54.2 for compatibility with golang

# Original PR Body below