### PR TITLE
[v0.88] Checkout OSS release branch for go-build <= 0.88

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -30,7 +30,7 @@ blocks:
     env_vars:
       # The branch to test the current go-build against
       - name: CALICO_BRANCH
-        value: master
+        value: release-v3.26
     jobs:
     - name: Build and push image
       commands:
@@ -40,9 +40,8 @@ blocks:
       - export VERSION=$BRANCH_NAME
       - make image ARCH=$TARGET_ARCH
       - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make push ARCH=$TARGET_ARCH CONFIRM=true; fi
-      - git clone git@github.com:projectcalico/calico.git calico
+      - git clone -b "${CALICO_BRANCH}" --depth 1 git@github.com:projectcalico/calico.git calico
       - cd calico
-      - git checkout "${CALICO_BRANCH}"
       - perl -0777 -pi -e's/GO_BUILD_VER\s*[?:]?=\s*\K[\.0-9a-z]+/'"${SEMAPHORE_GIT_BRANCH}-${TARGET_ARCH}"'/' metadata.mk
       - if [ "${TARGET_ARCH}" == "amd64" ]; then cd felix && make ut && cd ../calicoctl && make ut && cd ../libcalico-go && make ut; fi
       matrix:


### PR DESCRIPTION
We upgraded clang to v15 in Calico OSS so older go-build that still ships clang v12 won't pass amd64 UTs. This change checkout current Calico OSS release-v3.26 that is still using clang v12.