### PR TITLE
[v0.89] Clone depth 1 when running calico OSS build UTs

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -40,9 +40,8 @@ blocks:
       - export VERSION=$BRANCH_NAME
       - make image ARCH=$TARGET_ARCH
       - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make push ARCH=$TARGET_ARCH CONFIRM=true; fi
-      - git clone git@github.com:projectcalico/calico.git calico
+      - git clone -b "${CALICO_BRANCH}" --depth 1 git@github.com:projectcalico/calico.git calico
       - cd calico
-      - git checkout "${CALICO_BRANCH}"
       - perl -0777 -pi -e's/GO_BUILD_VER\s*[?:]?=\s*\K[\.0-9a-z]+/'"${SEMAPHORE_GIT_BRANCH}-${TARGET_ARCH}"'/' metadata.mk
       - if [ "${TARGET_ARCH}" == "amd64" ]; then cd felix && make ut && cd ../calicoctl && make ut && cd ../libcalico-go && make ut; fi
       matrix:


### PR DESCRIPTION
Pick https://github.com/projectcalico/go-build/pull/483 into release v0.89 branch.