### PR TITLE
Update release tag calculation

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -889,7 +889,7 @@ fetch-all:
 # git-dev-tag retrieves the dev tag for the current commit (the one are dev images are tagged with).
 git-dev-tag = $(shell git describe --tags --long --always --abbrev=12 --match "*dev*")
 # git-release-tag-from-dev-tag get's the release version from the current commits dev tag.
-git-release-tag-from-dev-tag = $(shell echo $(call git-dev-tag) | grep -P -o "^v\d*.\d*.\d*")
+git-release-tag-from-dev-tag = $(shell echo $(call git-dev-tag) | grep -P -o "^v\d*.\d*.\d*(-.*)?(?=-$(DEV_TAG_SUFFIX))")
 # git-release-tag-for-current-commit gets the release tag for the current commit if there is one.
 git-release-tag-for-current-commit = $(shell git describe --tags --exact-match --exclude "*dev*")
 


### PR DESCRIPTION
A simple update to release tag calculation.

The old regex would search for specifically `v\d*.\d*.\d*`, which would correctly extract a standard `vX.Y.Z` version. With our new `vX.Y.Z-a.b` versioning, this would mangle the intended version name.

The new regex searches for `v\d*.\d*.\d*`, then an optional `-.*`, and then includes a lookahead for `-<dev tag suffix>`. This causes the optional `-.*` to end before the dev tag suffix, wherever that is in the `git describe`, and should theoretically support any similar semver-compatible tags we might use in future.

Examples (for `DEV_TAG_SUFFIX=devel`)

| | v3.18.0-devel | v3.18.0-1.1-devel |
|----|--------|--------|
| Old | v3.18.0 | v3.18.0 |
| New | v3.18.0 | v3.18.0-1.1 |

This shouldn't cause any unforseen side effects, unless
1. DEV_TAG_SUFFIX is set incorrectly somewhere; or
2. DEV_TAG_SUFFIX is used incorrectly somewhere