### PR TITLE
Updated the s390x dockerfile to Build ModSecurity for Dikastes

### DIFF
--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -14,6 +14,7 @@ LABEL maintainer="LoZ Open SourceEcosystem (https://www.ibm.com/developerworks/c
 ARG GO_LINT_VERSION=v1.54.2
 ARG K8S_VERSION=v1.26.3
 ARG MANIFEST_TOOL_VERSION=v1.0.2
+ARG MODSEC_VERSION=v3.0.10
 
 # Enable non-native builds of this image on an amd64 hosts.
 # This must be the first RUN command in this file!
@@ -74,6 +75,12 @@ RUN chmod -R 777 $GOPATH
 
 RUN curl -sfL https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-s390x -o /usr/bin/manifest-tool && \
     chmod +x /usr/bin/manifest-tool
+
+# Build ModSecurity for Dikastes.
+RUN git clone -b ${MODSEC_VERSION} --depth 1 --recurse-submodules --shallow-submodules https://github.com/SpiderLabs/ModSecurity.git /build && \
+    cd /build && ./build.sh && ./configure && \
+    make && make install && \
+    rm -fr /build
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
## Description
```
The s390x dockerfile for the go-build is updated with the ModSecurity code which will provide 
ModSecurity for Dikastes with the MODSEC_VERSION=v3.0.10 . 
```

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
