### PR TITLE
Add back push-manifests in Makefile

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -840,6 +840,12 @@ push-image-arch-to-registry-%:
 		$(NOECHO) $(NOOP)\
 	)
 
+# push multi-arch manifest where supported.
+push-manifests: var-require-all-IMAGETAG  $(addprefix sub-manifest-,$(call escapefs,$(PUSH_MANIFEST_IMAGES)))
+sub-manifest-%:
+	$(DOCKER) manifest create $(call unescapefs,$*):$(IMAGETAG) $(addprefix --amend ,$(addprefix $(call unescapefs,$*):$(IMAGETAG)-,$(VALIDARCHES)))
+	$(DOCKER) manifest push $(call unescapefs,$*):$(IMAGETAG)
+
 # cd-common tags and pushes images with the branch name and git version. This target uses PUSH_IMAGES, BUILD_IMAGE,
 # and BRANCH_NAME env variables to figure out what to tag and where to push it to.
 cd-common: var-require-one-of-CONFIRM-DRYRUN var-require-all-BRANCH_NAME


### PR DESCRIPTION
Reimplement `push-manifests` in `Makefile.common` using `docker manifest` command [1]. It was removed in [2]. This change is ported from [3].

[1] https://docs.docker.com/engine/reference/commandline/manifest/
[2] https://github.com/projectcalico/go-build/pull/490/files#diff-f190d29e2cad4f32539c8b73d8af07c77f0aac63b5c6553c06b117c08a70b494L876
[3] https://github.com/projectcalico/calico/pull/8254