### PR TITLE
[v0.90] Add mingw64-gcc package for Windows CGO builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,12 @@ RUN set -eux; \
             libmodsecurity-devel; \
     fi
 
+RUN set -eux; \
+    if [ "${TARGETARCH}" = "amd64" ]; then \
+        dnf --enablerepo=powertools install -y \
+            mingw64-gcc; \
+    fi
+
 RUN dnf clean all
 
 # Install Go official release


### PR DESCRIPTION
Pick https://github.com/projectcalico/go-build/pull/500 into release v0.90 branch.