### PR TITLE
Use host native calico/go-build

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -132,14 +132,8 @@ endif
 # the one for the host should contain all the necessary cross-compilation tools
 # we do not need to use the arch since go-build:v0.15 now is multi-arch manifest
 GO_BUILD_IMAGE ?= calico/go-build
-CALICO_BUILD    = $(GO_BUILD_IMAGE):$(GO_BUILD_VER)
+CALICO_BUILD    = $(GO_BUILD_IMAGE):$(GO_BUILD_VER)-$(BUILDARCH)
 
-BIRD_VERSION=v0.3.1
-COREDNS_VERSION=1.5.2
-ETCD_VERSION=v3.5.1
-K8S_VERSION=v1.23.2
-KUBECTL_VERSION=v1.23.2
-PROTOC_VER=v0.1
 PROTOC_CONTAINER=calico/protoc:$(PROTOC_VER)-$(BUILDARCH)
 
 ifeq ($(GIT_USE_SSH),true)


### PR DESCRIPTION
This changeset enforces host native calico/go-build and removes outdated version definitions.