### PR TITLE
Copy proper dynamic loader symbolic links for all supported arches

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -2,30 +2,45 @@ FROM --platform=linux/amd64 calico/qemu-user-static:latest as qemu
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as ubi
 
+ARG LDSONAME
+
 COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 
 RUN microdnf upgrade -y
 
-FROM scratch as source
+# Prepare a rootfs for necessary files from UBI.
+# Symbolic links are preserved.
+RUN mkdir -p /rootfs/lib64 /rootfs/etc
 
-ARG LDSONAME
+# Copy dynamic loader and symbolic links.
+# Note: The dynamic loader name and links might be different in a future release.
+RUN cp /lib64/ld-2.28.so /rootfs/lib64/ld-2.28.so
+RUN set -eux; \
+    cp -a /lib64/${LDSONAME} /rootfs/lib64/${LDSONAME}; \
+    if [ -f /lib/${LDSONAME} ]; then \
+        mkdir -p /rootfs/lib && cp -a /lib/${LDSONAME} /rootfs/lib/${LDSONAME}; \
+    fi
 
 # Required external C dependencies for CGO builds.
-COPY --from=ubi /lib64/${LDSONAME} /lib64/${LDSONAME}
-COPY --from=ubi /lib64/libc.so.6 /lib64/libc.so.6
-COPY --from=ubi /lib64/libpthread.so.0 /lib64/libpthread.so.0
-COPY --from=ubi /lib64/libresolv.so.2 /lib64/libresolv.so.2
+RUN cp /lib64/libc.so.6 /rootfs/lib64/libc.so.6
+RUN cp /lib64/libpthread.so.0 /rootfs/lib64/libpthread.so.0
+RUN cp /lib64/libresolv.so.2 /rootfs/lib64/libresolv.so.2
 
 # glibc NSS plugins and config files.
-COPY --from=ubi /lib64/libnss_dns.so.2 /lib64/libnss_dns.so.2
-COPY --from=ubi /lib64/libnss_files.so.2 /lib64/libnss_files.so.2
+RUN cp /lib64/libnss_dns.so.2 /rootfs/lib64/libnss_dns.so.2
+RUN cp /lib64/libnss_files.so.2 /rootfs/lib64/libnss_files.so.2
 
-COPY --from=ubi /etc/host.conf /etc/host.conf
-COPY --from=ubi /etc/hosts /etc/hosts
-COPY --from=ubi /etc/networks /etc/networks
-COPY --from=ubi /etc/nsswitch.conf /etc/nsswitch.conf
+RUN cp /etc/host.conf /rootfs/etc/host.conf
+RUN cp /etc/hosts /rootfs/etc/hosts
+RUN cp /etc/networks /rootfs/etc/networks
+RUN cp /etc/nsswitch.conf /rootfs/etc/nsswitch.conf
 
-COPY --from=ubi /etc/os-release /etc/os-release
+# Copy base image release info.
+RUN cp /etc/os-release /rootfs/etc/os-release
+
+FROM scratch as source
+
+COPY --from=ubi /rootfs /
 
 # tmp.tar has a /tmp with the correct permissions 01777.
 ADD tmp.tar /


### PR DESCRIPTION
This change copies dynamic loader symbolic links into calico/base image. As they varies among different arches, they are summarized as follows:

| arch    | loader location   | symblink in /lib64    | symblink in /lib      |
| ------- | ----------------- | --------------------- | --------------------- |
| amd64   | /lib64/ld-2.28.so | ld-linux-x86-64.so.2  | N/A                   |
| arm64   | /lib64/ld-2.28.so | ld-linux-aarch64.so.1 | ld-linux-aarch64.so.1 |
| ppc64le | /lib64/ld-2.28.so | ld64.so.2             | N/A                   |
| s390x   | /lib64/ld-2.28.so | ld64.so.1             | ld64.so.1             |

Note that the loader name and symbolic links will change in UBI9 so we need to revisit this when we upgrade.