### PR TITLE
Clean up docker buildx output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,12 @@ QEMU_IMAGE_CREATED=.qemu.created
 .PHONY: image-qemu
 image-qemu: $(QEMU_IMAGE_CREATED)
 $(QEMU_IMAGE_CREATED):
-	docker buildx build --load --platform=linux/amd64 --pull -t $(QEMU_IMAGE) -f qemu/Dockerfile qemu
+	docker buildx build --progress=plain --load --platform=linux/amd64 --pull -t $(QEMU_IMAGE) -f qemu/Dockerfile qemu
 	touch $@
 
 .PHONY: image
 image: register image-qemu
-	docker buildx build --load --platform=linux/$(ARCH) -t $(GOBUILD_ARCH_IMAGE) -f Dockerfile .
+	docker buildx build --progress=plain --load --platform=linux/$(ARCH) -t $(GOBUILD_ARCH_IMAGE) -f Dockerfile .
 
 .PHONY: image-all
 image-all: $(addprefix sub-image-,$(ARCHES))
@@ -82,7 +82,7 @@ sub-image-%:
 
 .PHONY: image-base
 image-base: register image-qemu
-	docker buildx build --load --platform=linux/$(ARCH) --build-arg LDSONAME=$(LDSONAME) -t $(BASE_ARCH_IMAGE) -f base/Dockerfile base
+	docker buildx build --progress=plain --load --platform=linux/$(ARCH) --build-arg LDSONAME=$(LDSONAME) -t $(BASE_ARCH_IMAGE) -f base/Dockerfile base
 
 .PHONY: image-base-all
 image-base-all: $(addprefix sub-image-base-,$(ARCHES))

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,10 @@ BASE_ARCH_IMAGE ?= $(BASE_IMAGE)-$(ARCH)
 QEMU ?= calico/qemu-user-static
 QEMU_IMAGE ?= $(QEMU):latest
 
+ifdef CI
+DOCKER_PROGRESS := --progress=plain
+endif
+
 ###############################################################################
 # Building images
 ###############################################################################
@@ -68,12 +72,12 @@ QEMU_IMAGE_CREATED=.qemu.created
 .PHONY: image-qemu
 image-qemu: $(QEMU_IMAGE_CREATED)
 $(QEMU_IMAGE_CREATED):
-	docker buildx build --progress=plain --load --platform=linux/amd64 --pull -t $(QEMU_IMAGE) -f qemu/Dockerfile qemu
+	docker buildx build $(DOCKER_PROGRESS) --load --platform=linux/amd64 --pull -t $(QEMU_IMAGE) -f qemu/Dockerfile qemu
 	touch $@
 
 .PHONY: image
 image: register image-qemu
-	docker buildx build --progress=plain --load --platform=linux/$(ARCH) -t $(GOBUILD_ARCH_IMAGE) -f Dockerfile .
+	docker buildx build $(DOCKER_PROGRESS) --load --platform=linux/$(ARCH) -t $(GOBUILD_ARCH_IMAGE) -f Dockerfile .
 
 .PHONY: image-all
 image-all: $(addprefix sub-image-,$(ARCHES))
@@ -82,7 +86,7 @@ sub-image-%:
 
 .PHONY: image-base
 image-base: register image-qemu
-	docker buildx build --progress=plain --load --platform=linux/$(ARCH) --build-arg LDSONAME=$(LDSONAME) -t $(BASE_ARCH_IMAGE) -f base/Dockerfile base
+	docker buildx build $(DOCKER_PROGRESS) --load --platform=linux/$(ARCH) --build-arg LDSONAME=$(LDSONAME) -t $(BASE_ARCH_IMAGE) -f base/Dockerfile base
 
 .PHONY: image-base-all
 image-base-all: $(addprefix sub-image-base-,$(ARCHES))


### PR DESCRIPTION
Cleans up the output from `docker buildx build` when running in CI by setting the progress to 'plain', removing a significant amount of redundant and difficult-to-read output.

```
❯ wc -l standard-output.txt new-output.txt
  4005 standard-output.txt
   455 new-output.txt
```