### PR TITLE
Build and add `lipo` from Apple's cctools for making universal binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,6 +130,21 @@ RUN set -eux; \
     gcc -Wall -O2 /tmp/su-exec.c -o /usr/bin/su-exec; \
     rm -f /tmp/su-exec.c
 
+# Build lipo (for creating macOS universal binaries)
+
+RUN --mount=type=tmpfs,target=/tmp/cctools-port \
+    set -eux; \
+    if [ "${TARGETARCH}" = "amd64" ]; then \
+    dnf install -y libdispatch && \
+    git clone https://github.com/tpoechtrager/cctools-port /tmp/cctools-port && \
+        cd /tmp/cctools-port/cctools && \
+        ./configure && \
+        make -j12 -C libmacho && \
+        make -j12 -C libstuff && \
+        make -j12 -C misc lipo && \
+        cp misc/lipo /usr/local/bin; \
+    fi
+
 # Install Go utilities
 
 # controller-gen is used for generating CRD files.

--- a/Dockerfile
+++ b/Dockerfile
@@ -139,9 +139,9 @@ RUN --mount=type=tmpfs,target=/tmp/cctools-port \
     git clone https://github.com/tpoechtrager/cctools-port /tmp/cctools-port && \
         cd /tmp/cctools-port/cctools && \
         ./configure && \
-        make -j12 -C libmacho && \
-        make -j12 -C libstuff && \
-        make -j12 -C misc lipo && \
+        make -j4 -C libmacho && \
+        make -j4 -C libstuff && \
+        make -j4 -C misc lipo && \
         cp misc/lipo /usr/local/bin; \
     fi
 


### PR DESCRIPTION
We currently build amd64 and arm64 binaries for macOS but release them separately. Using Apple's `lipo` tool, we can build a universal binary which will run natively on both arm64 and amd64 macs.

This would allow us to publish just one binary, and allow users to download just one binary, without having to worry about which is which (and it's easy to mistake 'amd64' and 'arm64' and download the wrong one by accident).

Currently this only builds the `lipo` binary for inclusion into the amd64 docker image. It does build successfully on the arm64 docker image as well, but I'm not sure if it's important to build it on both.

On my system it adds about 20 seconds to the image build time, which is about half of what it takes to download `kube-apiserver`.