### PR TITLE
Fix generation of image tags based on dev tags

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -840,7 +840,7 @@ sub-manifest-%:
 # and BRANCH_NAME env variables to figure out what to tag and where to push it to.
 cd-common: var-require-one-of-CONFIRM-DRYRUN var-require-all-BRANCH_NAME
 	$(MAKE) retag-build-images-with-registries push-images-to-registries push-manifests IMAGETAG=$(if $(IMAGETAG_PREFIX),$(IMAGETAG_PREFIX)-)$(BRANCH_NAME) EXCLUDEARCH="$(EXCLUDEARCH)"
-	$(MAKE) retag-build-images-with-registries push-images-to-registries push-manifests IMAGETAG=$(if $(IMAGETAG_PREFIX),$(IMAGETAG_PREFIX)-)$(GIT_VERSION) EXCLUDEARCH="$(EXCLUDEARCH)"
+	$(MAKE) retag-build-images-with-registries push-images-to-registries push-manifests IMAGETAG=$(if $(IMAGETAG_PREFIX),$(IMAGETAG_PREFIX)-)$(call git-dev-tag) EXCLUDEARCH="$(EXCLUDEARCH)"
 
 ###############################################################################
 # Release targets and helpers


### PR DESCRIPTION
Currently, the generation of image tags yields the incorrect tag when the current commit has the dev tag on it.

This is because https://github.com/projectcalico/go-build/pull/516 removed the usage of the `--long` flag when generating the image tag from `git describe`.

This PR uses `git-dev-tag` instead of `GIT_VERSION` to restore the long flag.
