### PR TITLE
Use a bigger semaphore build machine type

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: go-build
 agent:
   machine:
-    type: e1-standard-2
+    type: e1-standard-4
     os_image: ubuntu2004
 
 execution_time_limit:


### PR DESCRIPTION
`e1-standard-2` is too small for toolchain build and UTs so bump semaphore build machine to `e1-standard-4`