### PR TITLE
[v0.92] Use v3.28 for CI and reenable calico tests

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -33,7 +33,7 @@ blocks:
       env_vars:
         # The branch to test the current go-build against
         - name: CALICO_BRANCH
-          value: release-v3.27
+          value: release-v3.28
       jobs:
         - name: Build and push go-build image
           commands:
@@ -46,8 +46,7 @@ blocks:
             - git clone -b "${CALICO_BRANCH}" --depth 1 git@github.com:projectcalico/calico.git calico
             - cd calico
             - perl -0777 -pi -e's/GO_BUILD_VER\s*[?:]?=\s*\K[\.0-9a-z]+/'"${SEMAPHORE_GIT_BRANCH}"'/' metadata.mk
-            # temporarily skip testing due to needing an update in the calico repo
-            #- if [ "${TARGET_ARCH}" == "amd64" ]; then cd felix && make ut && cd ../calicoctl && make ut && cd ../libcalico-go && make ut; fi
+            - if [ "${TARGET_ARCH}" == "amd64" ]; then cd felix && make ut && cd ../calicoctl && make ut && cd ../libcalico-go && make ut; fi
           matrix:
             - env_var: TARGET_ARCH
               values: ["amd64", "arm64", "ppc64le", "s390x"]


### PR DESCRIPTION
Use Calico v3.28 and reenable tests temporarily disabled in https://github.com/projectcalico/go-build/pull/601