### PR TITLE
Patch controller-gen tool with Calico types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG GOLANG_SHA256_S390X=6bd72fcef72b046b6282c2d1f2c38f31600e4fe9361fcd8341500c75
 
 ARG CLANG_VERSION=18.1.8
 ARG CONTAINERREGISTRY_VERSION=v0.20.2
-ARG CONTROLLER_GEN_VERSION=v0.16.5
+ARG CONTROLLER_TOOLS_VERSION=v0.16.5
 ARG GO_LINT_VERSION=v1.61.0
 ARG K8S_VERSION=v1.30.5
 ARG K8S_LIBS_VERSION=v0.30.5
@@ -42,6 +42,7 @@ RUN dnf upgrade -y && dnf install -y \
     libtool \
     make \
     openssh-clients \
+    patch \
     pcre-devel \
     pkg-config \
     protobuf-compiler \
@@ -128,9 +129,14 @@ RUN set -eux; \
 # Install Go utilities
 
 # controller-gen is used for generating CRD files.
+COPY patches/controller-gen-Support-Calico-NumOrString-types.patch /tmp/controller-tools/calico.patch
+
 RUN set -eux; \
     if [ "${TARGETARCH}" = "amd64" ]; then \
-        curl -sfL https://github.com/kubernetes-sigs/controller-tools/releases/download/${CONTROLLER_GEN_VERSION}/controller-gen-linux-amd64 -o /usr/local/bin/controller-gen && chmod +x /usr/local/bin/controller-gen; \
+        curl -sfL https://github.com/kubernetes-sigs/controller-tools/archive/refs/tags/${CONTROLLER_TOOLS_VERSION}.tar.gz | tar xz --strip-components 1 -C /tmp/controller-tools; \
+        cd /tmp/controller-tools && patch -p1 < calico.patch && CGO_ENABLED=0 go build -o /usr/local/bin/controller-gen -v -buildvcs=false \
+            -ldflags "-X sigs.k8s.io/controller-tools/pkg/version.version=${CONTROLLER_TOOLS_VERSION} -s -w" ./cmd/controller-gen; \
+        rm -fr /tmp/controller-tools; \
     fi
 
 # crane is needed for our release targets to copy images from the dev registries to the release registries.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,11 @@ ARG GOLANG_SHA256_S390X=6bd72fcef72b046b6282c2d1f2c38f31600e4fe9361fcd8341500c75
 
 ARG CLANG_VERSION=18.1.8
 ARG CONTAINERREGISTRY_VERSION=v0.20.2
+ARG CONTROLLER_GEN_VERSION=v0.16.5
 ARG GO_LINT_VERSION=v1.61.0
 ARG K8S_VERSION=v1.30.5
 ARG K8S_LIBS_VERSION=v0.30.5
 ARG MOCKERY_VERSION=2.46.3
-
-ARG CALICO_CONTROLLER_TOOLS_VERSION=calico-0.1
 
 ENV PATH=/usr/local/go/bin:$PATH
 
@@ -129,12 +128,9 @@ RUN set -eux; \
 # Install Go utilities
 
 # controller-gen is used for generating CRD files.
-# Download a version of controller-gen that has been updated to support additional types (e.g., float).
-# We can remove this once we update the Calico v3 APIs to use only types which are supported by the upstream controller-gen
-# tooling. Example: float, all the types in the numorstring package, etc.
 RUN set -eux; \
     if [ "${TARGETARCH}" = "amd64" ]; then \
-        curl -sfL https://github.com/projectcalico/controller-tools/releases/download/${CALICO_CONTROLLER_TOOLS_VERSION}/controller-gen -o /usr/local/bin/controller-gen && chmod +x /usr/local/bin/controller-gen; \
+        curl -sfL https://github.com/kubernetes-sigs/controller-tools/releases/download/${CONTROLLER_GEN_VERSION}/controller-gen-linux-amd64 -o /usr/local/bin/controller-gen && chmod +x /usr/local/bin/controller-gen; \
     fi
 
 # crane is needed for our release targets to copy images from the dev registries to the release registries.

--- a/patches/controller-gen-Support-Calico-NumOrString-types.patch
+++ b/patches/controller-gen-Support-Calico-NumOrString-types.patch
@@ -1,0 +1,65 @@
+From d3db9cd382359bdb1afa94f40e29ad9bebdeaf61 Mon Sep 17 00:00:00 2001
+From: Jiawei Huang <jiawei@tigera.io>
+Date: Fri, 6 Dec 2024 15:35:46 -0800
+Subject: [PATCH] Support Calico NumOrString types
+
+---
+ pkg/crd/known_types.go | 35 +++++++++++++++++++++++++++++++++++
+ 1 file changed, 35 insertions(+)
+
+diff --git a/pkg/crd/known_types.go b/pkg/crd/known_types.go
+index ab939328..8f9fa67d 100644
+--- a/pkg/crd/known_types.go
++++ b/pkg/crd/known_types.go
+@@ -22,6 +22,35 @@ import (
+ 	"sigs.k8s.io/controller-tools/pkg/loader"
+ )
+ 
++// Custom logic for numOrString types.
++var numOrString = func(p *Parser, pkg *loader.Package) {
++	p.Schemata[TypeIdent{Name: "NumOrString", Package: pkg}] = apiext.JSONSchemaProps{
++		XIntOrString: true,
++		AnyOf: []apiext.JSONSchemaProps{
++			{Type: "integer"},
++			{Type: "string"},
++		},
++		Pattern: "^.*",
++	}
++	p.Schemata[TypeIdent{Name: "Protocol", Package: pkg}] = apiext.JSONSchemaProps{
++		XIntOrString: true,
++		AnyOf: []apiext.JSONSchemaProps{
++			{Type: "integer"},
++			{Type: "string"},
++		},
++		Pattern: "^.*",
++	}
++	p.Schemata[TypeIdent{Name: "Port", Package: pkg}] = apiext.JSONSchemaProps{
++		XIntOrString: true,
++		AnyOf: []apiext.JSONSchemaProps{
++			{Type: "integer"},
++			{Type: "string"},
++		},
++		Pattern: "^.*",
++	}
++	p.AddPackage(pkg) // get the rest of the types
++}
++
+ // KnownPackages overrides types in some comment packages that have custom validation
+ // but don't have validation markers on them (since they're from core Kubernetes).
+ var KnownPackages = map[string]PackageOverride{
+@@ -50,6 +79,12 @@ var KnownPackages = map[string]PackageOverride{
+ 		p.AddPackage(pkg) // get the rest of the types
+ 	},
+ 
++	// numorstring could come from different places. It was moved to the api repository
++	// around the time of Calico v3.20.
++	"github.com/projectcalico/libcalico-go/lib/numorstring": numOrString,
++	"github.com/projectcalico/api/pkg/lib/numorstring":      numOrString,
++	"github.com/tigera/api/pkg/lib/numorstring":             numOrString,
++
+ 	"k8s.io/apimachinery/pkg/api/resource": func(p *Parser, pkg *loader.Package) {
+ 		p.Schemata[TypeIdent{Name: "Quantity", Package: pkg}] = apiext.JSONSchemaProps{
+ 			// TODO(directxman12): regexp validation for this (or get kube to support it as a format value)
+-- 
+2.47.1
+


### PR DESCRIPTION
This change downloads the controller-tools from official release and patches the `controller-gen` utility to support Calico types.