### PR TITLE
add CLEANUPLEVEL arg for image-base

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -56,9 +56,9 @@ blocks:
         - name: Build calico/go-build image
           commands:
             - make -C images calico-go-build-image ARCH=$ARCH
-            - git clone -b "${CALICO_BRANCH}" --depth 1 git@github.com:projectcalico/calico.git calico
-            - cd calico
-            - sed -i 's/^GO_BUILD_VER=.*$/GO_BUILD_VER=${VERSION_TAG}/' metadata.mk
+            - if [ "${ARCH}" == "amd64" ]; git clone -b "${CALICO_BRANCH}" --depth 1 git@github.com:projectcalico/calico.git calico; fi
+            - if [ "${ARCH}" == "amd64" ]; cd calico; fi
+            - if [ "${ARCH}" == "amd64" ]; sed -i 's/^GO_BUILD_VER=.*$/GO_BUILD_VER=${VERSION_TAG}/' metadata.mk; fi
             - if [ "${ARCH}" == "amd64" ]; then cd felix && make ut && cd ../calicoctl && make ut && cd ../libcalico-go && make ut; fi
           matrix:
             - env_var: ARCH
@@ -70,7 +70,15 @@ blocks:
       jobs:
         - name: Build calico/base image
           commands:
-            - make -C images calico-base-image ARCH=$ARCH
+            - make -C images calico-base-image ARCH=$ARCH CALICO_BASE_CLEANUP=$CALICO_BASE_CLEANUP
+            # Verify the unstripped calico/base builds Calico modules (only necessary for unstripped base where we have no other visibility into proper Calico function).
+            - if [ "${ARCH}" == "amd64" -a "$CALICO_BASE_CLEANUP" == "unstripped" ]; then git clone -b "${CALICO_BRANCH}" --depth 1 git@github.com:projectcalico/calico.git calico; fi
+            - if [ "${ARCH}" == "amd64" -a "$CALICO_BASE_CLEANUP" == "unstripped" ]; then cd calico; fi
+            - if [ "${ARCH}" == "amd64" -a "$CALICO_BASE_CLEANUP" == "unstripped" ]; then sed -i 's/^CALICO_BASE=.*$/CALICO_BASE=base-unstripped:${VERSION_TAG}-amd64/' metadata.mk; fi
+            - if [ "${ARCH}" == "amd64" -a "$CALICO_BASE_CLEANUP" == "unstripped" ]; then make NO_DOCKER_PULL=1 -C apiserver image && make NO_DOCKER_PULL=1 -C calicoctl image && make NO_DOCKER_PULL=1 -C cni-plugin image && make NO_DOCKER_PULL=1 -C typha image; fi
+
           matrix:
             - env_var: ARCH
               values: ["amd64", "arm64", "ppc64le", "s390x"]
+            - env_var: CALICO_BASE_CLEANUP
+              values: ["stripped", "unstripped"]

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -72,7 +72,7 @@ blocks:
           commands:
             - make -C images calico-base-image ARCH=$ARCH CALICO_BASE_CLEANUP=$CALICO_BASE_CLEANUP
             # Verify the unstripped calico/base builds Calico modules (only necessary for unstripped base where we have no other visibility into proper Calico function).
-            - if [ "${ARCH}" == "amd64" -a "$CALICO_BASE_CLEANUP" == "unstripped" ]; then git clone -b "${CALICO_BRANCH}" --depth 1 git@github.com:projectcalico/calico.git calico; fi
+            - if [ "${ARCH}" == "amd64" -a "$CALICO_BASE_CLEANUP" == "unstripped" ]; then git clone --depth 1 git@github.com:projectcalico/calico.git calico; fi
             - if [ "${ARCH}" == "amd64" -a "$CALICO_BASE_CLEANUP" == "unstripped" ]; then cd calico; fi
             - if [ "${ARCH}" == "amd64" -a "$CALICO_BASE_CLEANUP" == "unstripped" ]; then sed -i 's/^CALICO_BASE=.*$/CALICO_BASE=base-unstripped:${VERSION_TAG}-amd64/' metadata.mk; fi
             - if [ "${ARCH}" == "amd64" -a "$CALICO_BASE_CLEANUP" == "unstripped" ]; then make NO_DOCKER_PULL=1 -C apiserver image && make NO_DOCKER_PULL=1 -C calicoctl image && make NO_DOCKER_PULL=1 -C cni-plugin image && make NO_DOCKER_PULL=1 -C typha image; fi

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -56,9 +56,9 @@ blocks:
         - name: Build calico/go-build image
           commands:
             - make -C images calico-go-build-image ARCH=$ARCH
-            - if [ "${ARCH}" == "amd64" ]; git clone -b "${CALICO_BRANCH}" --depth 1 git@github.com:projectcalico/calico.git calico; fi
-            - if [ "${ARCH}" == "amd64" ]; cd calico; fi
-            - if [ "${ARCH}" == "amd64" ]; sed -i 's/^GO_BUILD_VER=.*$/GO_BUILD_VER=${VERSION_TAG}/' metadata.mk; fi
+            - if [ "${ARCH}" == "amd64" ]; then git clone -b "${CALICO_BRANCH}" --depth 1 git@github.com:projectcalico/calico.git calico; fi
+            - if [ "${ARCH}" == "amd64" ]; then cd calico; fi
+            - if [ "${ARCH}" == "amd64" ]; then sed -i 's/^GO_BUILD_VER=.*$/GO_BUILD_VER=${VERSION_TAG}/' metadata.mk; fi
             - if [ "${ARCH}" == "amd64" ]; then cd felix && make ut && cd ../calicoctl && make ut && cd ../libcalico-go && make ut; fi
           matrix:
             - env_var: ARCH

--- a/README.md
+++ b/README.md
@@ -73,3 +73,38 @@ docker run --rm --privileged multiarch/qemu-user-static:register
 ```
 
 If a cross built binary is executed in the go-build container qemu-static will automatically be used.
+
+# Calico Base
+
+Calico Base is the base-image used for various containerized Calico components, e.g. Typha.
+
+## Building the image
+
+To build the image:
+
+```bash
+make image
+```
+
+or
+
+```bash
+make -C images calico-base-image
+```
+
+## Disable image stripping
+
+By default, required libraries (.so files) are copied individually from an UBI-minimal base-image onto a scratch image.
+To instead preserve the entire UBI base image:
+
+```bash
+BASE_CLEANUP_LEVEL=unstripped make image
+```
+
+## Override the default UBI base
+
+Once image-stripping is disabled, you may bring your own UBI-style base image:
+
+```bash
+BASE_BASEIMG=some/ubi BASE_CLEANUP_LEVEL=unstripped make -C images calico-base-image
+```

--- a/images/Makefile
+++ b/images/Makefile
@@ -9,6 +9,13 @@ CALICO_GO_BUILD ?= go-build
 QEMU_USER_STATIC ?= $(DEV_REGISTRIES)/qemu-user-static
 QEMU_USER_STATIC_IMAGE_CREATED = .qemu-user-static.created
 
+# Base-image we'll use to build calico/base.
+BASE_BASEIMG ?= registry.access.redhat.com/ubi8/ubi-minimal:latest
+# Name of pkg manager binary, for installing deps on calico-base's UBI step.
+BASE_PKGMAN ?= microdnf
+# The level of cleanup we perform on the calico/base image. One-of: stripped, unstripped.
+BASE_CLEANUP_LEVEL ?= stripped
+
 .PHONY: image
 image: qemu-user-static-image calico-base-image calico-go-build-image
 
@@ -45,8 +52,14 @@ endif
 
 .PHONY: calico-base-image
 calico-base-image: register qemu-user-static-image
-	$(DOCKER_BUILD) --build-arg LDSONAME=$(LDSONAME) -t $(CALICO_BASE):latest-$(ARCH) -f calico-base/Dockerfile calico-base/
+	$(DOCKER_BUILD) \
+	  --build-arg LDSONAME=$(LDSONAME) \
+	  --build-arg CLEANUP_LEVEL=$(BASE_CLEANUP_LEVEL) \
+	  --build-arg BASE=$(BASE_BASEIMG) \
+	  --build-arg PKGMAN=$(BASE_PKGMAN) \
+	  -t $(CALICO_BASE):latest-$(ARCH) -f calico-base/Dockerfile calico-base/
 	$(MAKE) BUILD_IMAGES=$(CALICO_BASE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
+
 
 .PHONY: calico-base-image-all
 calico-base-image-all: $(addprefix sub-calico-base-image-,$(VALIDARCHES))

--- a/images/Makefile
+++ b/images/Makefile
@@ -3,18 +3,22 @@ include ../Makefile.common
 
 VERSION_TAG ?= latest
 
-CALICO_BASE ?= base
-CALICO_GO_BUILD ?= go-build
-
-QEMU_USER_STATIC ?= $(DEV_REGISTRIES)/qemu-user-static
-QEMU_USER_STATIC_IMAGE_CREATED = .qemu-user-static.created
-
 # Base-image we'll use to build calico/base.
 BASE_BASEIMG ?= registry.access.redhat.com/ubi8/ubi-minimal:latest
 # Name of pkg manager binary, for installing deps on calico-base's UBI step.
 BASE_PKGMAN ?= microdnf
 # The level of cleanup we perform on the calico/base image. One-of: stripped, unstripped.
 BASE_CLEANUP_LEVEL ?= stripped
+
+ifeq ($(BASE_CLEANUP_LEVEL), unstripped)
+CALICO_BASE ?= base-unstripped
+else
+CALICO_BASE ?= base
+endif
+CALICO_GO_BUILD ?= go-build
+
+QEMU_USER_STATIC ?= $(DEV_REGISTRIES)/qemu-user-static
+QEMU_USER_STATIC_IMAGE_CREATED = .qemu-user-static.created
 
 .PHONY: image
 image: qemu-user-static-image calico-base-image calico-go-build-image

--- a/images/calico-base/Dockerfile
+++ b/images/calico-base/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE
 
 FROM --platform=linux/amd64 calico/qemu-user-static:latest AS qemu
 
-FROM ${BASE} AS ubi
+FROM ${BASE} AS source-unstripped
 
 ARG LDSONAME
 
@@ -43,21 +43,15 @@ RUN cp /etc/nsswitch.conf /rootfs/etc/nsswitch.conf
 RUN cp /etc/os-release /rootfs/etc/os-release
 
 # Stripped image.
-FROM scratch AS intermediate-stripped
-
-COPY --from=ubi /rootfs /
-
+FROM scratch AS source-stripped
+COPY --from=source-unstripped /rootfs /
 # tmp.tar has a /tmp with the correct permissions 01777.
 ADD tmp.tar /
-
 COPY licenses /licenses/
 
-FROM scratch AS source-stripped
-COPY --from=intermediate-stripped / /
-
 # Unstripped image.
-FROM ${BASE} AS source-unstripped
-COPY --from=ubi / /
+FROM source-unstripped
+# Remove the prepped rootfs for the unstripped img.
 RUN rm -rf /rootfs
 
 # Choose which image is shipped.

--- a/images/calico-base/Dockerfile
+++ b/images/calico-base/Dockerfile
@@ -1,13 +1,17 @@
+# CLEANUPLEVEL defines the level of FS stripping we apply to the generated image.
+ARG CLEANUP_LEVEL
+ARG BASE
+
 FROM --platform=linux/amd64 calico/qemu-user-static:latest AS qemu
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS ubi
+FROM ${BASE} AS ubi
 
 ARG LDSONAME
 
 COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 
-RUN microdnf upgrade -y
-
+ARG PKGMAN
+RUN ${PKGMAN} upgrade -y
 # Prepare a rootfs for necessary files from UBI.
 # Symbolic links are preserved.
 RUN mkdir -p /rootfs/lib64 /rootfs/etc
@@ -38,7 +42,8 @@ RUN cp /etc/nsswitch.conf /rootfs/etc/nsswitch.conf
 # Copy base image release info.
 RUN cp /etc/os-release /rootfs/etc/os-release
 
-FROM scratch AS source
+# Stripped image.
+FROM scratch AS intermediate-stripped
 
 COPY --from=ubi /rootfs /
 
@@ -47,6 +52,13 @@ ADD tmp.tar /
 
 COPY licenses /licenses/
 
-FROM scratch
+FROM scratch AS source-stripped
+COPY --from=intermediate-stripped / /
 
-COPY --from=source / /
+# Unstripped image.
+FROM ${BASE} AS source-unstripped
+COPY --from=ubi / /
+RUN rm -rf /rootfs
+
+# Choose which image is shipped.
+FROM source-${CLEANUP_LEVEL}


### PR DESCRIPTION
`make BASE_CLEANUPLEVEL=unstripped image-base` Generates an image which is scannable,

e.g. `trivy image calico/base:latest-amd64`.

`make BASE_CLEANUPLEVEL=stripped image-base` , or just `make image-base` generates the usual image with clean FS.

Make/Docker arg `UBIBASE` allows injection of a different image to build from.

Arg `(BASE_)PKGMAN` allows adjustment of pkgmanager binary name - useful if say, using DNF rather than MicroDNF. Necessary when using non-minimal UBI.