### PR TITLE
Fix calico image push permission denied

### DIFF
--- a/.semaphore/promotions/calico-base.yml
+++ b/.semaphore/promotions/calico-base.yml
@@ -11,12 +11,12 @@ execution_time_limit:
 global_job_config:
   env_vars:
     - name: DEV_REGISTRIES
-      value: docker.io
+      value: calico
   secrets:
-    - name: docker-hub
+    - name: docker
   prologue:
     commands:
-      - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
       - checkout
 
 blocks:
@@ -28,8 +28,6 @@ blocks:
       env_vars:
         - name: BRANCH_NAME
           value: latest
-        - name: BUILD_IMAGES
-          value: calico/base
       jobs:
         - name: Linux multi-arch
           commands:

--- a/.semaphore/promotions/calico-go-build.yml
+++ b/.semaphore/promotions/calico-go-build.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Publish calico/go-build images
 agent:
   machine:
-    type: f1-standard-2
+    type: f1-standard-4
     os_image: ubuntu2204
 
 execution_time_limit:
@@ -11,12 +11,12 @@ execution_time_limit:
 global_job_config:
   env_vars:
     - name: DEV_REGISTRIES
-      value: docker.io
+      value: calico
   secrets:
-    - name: docker-hub
+    - name: docker
   prologue:
     commands:
-      - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
       - checkout
       # If an image build is triggered from a git tag, use the git tag name set by semaphore.
       # For utility changes that don't affect calico/go-build versions, we will append a release
@@ -37,8 +37,6 @@ blocks:
       env_vars:
         - name: BRANCH_NAME
           value: ${VERSION_TAG}
-        - name: BUILD_IMAGES
-          value: calico/go-build
         - name: LATEST_IMAGE_TAG
           value: ${VERSION_TAG}
       jobs:

--- a/.semaphore/promotions/qemu-user-static.yml
+++ b/.semaphore/promotions/qemu-user-static.yml
@@ -11,12 +11,12 @@ execution_time_limit:
 global_job_config:
   env_vars:
     - name: DEV_REGISTRIES
-      value: docker.io
+      value: calico
   secrets:
-    - name: docker-hub
+    - name: docker
   prologue:
     commands:
-      - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
       - checkout
 
 blocks:
@@ -28,8 +28,6 @@ blocks:
       env_vars:
         - name: BRANCH_NAME
           value: latest
-        - name: BUILD_IMAGES
-          value: calico/qemu-user-static
       jobs:
         - name: Linux amd64
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -50,9 +50,6 @@ blocks:
         machine:
           type: f1-standard-4
           os_image: ubuntu2204
-      secrets:
-        - name: quay-robot-calico-and-semaphoreci
-        - name: docker
       env_vars:
         # The branch to test the current go-build against
         - name: CALICO_BRANCH
@@ -60,7 +57,6 @@ blocks:
       jobs:
         - name: Build calico/go-build image
           commands:
-            - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
             - make -C images calico-go-build-image ARCH=$ARCH
             - git clone -b "${CALICO_BRANCH}" --depth 1 git@github.com:projectcalico/calico.git calico
             - cd calico
@@ -73,12 +69,9 @@ blocks:
   - name: calico/base image
     dependencies: []
     task:
-      secrets:
-        - name: docker
       jobs:
         - name: Build calico/base image
           commands:
-            - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
             - make -C images calico-base-image ARCH=$ARCH
           matrix:
             - env_var: ARCH

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -1,5 +1,5 @@
-include ../Makefile.common
 include ../lib.Makefile
+include ../Makefile.common
 
 .PHONY: build
 build: semvalidator-build-$(ARCH)

--- a/images/Makefile
+++ b/images/Makefile
@@ -1,17 +1,17 @@
-include ../Makefile.common
 include ../lib.Makefile
+include ../Makefile.common
 
-CALICO_BASE ?= calico/base
+CALICO_BASE ?= base
 CALICO_BASE_IMAGE ?= $(CALICO_BASE):latest
 CALICO_BASE_ARCH_IMAGE ?= $(CALICO_BASE_IMAGE)-$(ARCH)
 
-QEMU_USER_STATIC ?= calico/qemu-user-static
+QEMU_USER_STATIC ?= $(DEV_REGISTRIES)/qemu-user-static
 QEMU_USER_STATIC_IMAGE ?= $(QEMU_USER_STATIC):latest
 QEMU_USER_STATIC_IMAGE_CREATED = .qemu-user-static.created
 
 VERSION_TAG ?= $(shell ../hack/generate-version-tag-name.sh -f calico-go-build/versions.yaml)
 
-CALICO_GO_BUILD ?= calico/go-build
+CALICO_GO_BUILD ?= go-build
 CALICO_GO_BUILD_IMAGE ?= $(CALICO_GO_BUILD):$(VERSION_TAG)
 CALICO_GO_BUILD_ARCH_IMAGE ?= $(CALICO_GO_BUILD_IMAGE)-$(ARCH)
 
@@ -52,6 +52,7 @@ endif
 .PHONY: calico-base-image
 calico-base-image: register qemu-user-static-image
 	$(DOCKER_BUILD) --build-arg LDSONAME=$(LDSONAME) -t $(CALICO_BASE_ARCH_IMAGE) -f calico-base/Dockerfile calico-base/
+	$(MAKE) BUILD_IMAGES=$(CALICO_BASE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 
 .PHONY: calico-base-image-all
 calico-base-image-all: $(addprefix sub-calico-base-image-,$(VALIDARCHES))
@@ -59,7 +60,8 @@ sub-calico-base-image-%:
 	$(MAKE) calico-base-image ARCH=$*
 
 .PHONY: calico-base-cd
-calico-base-cd: calico-base-image-all cd-common
+calico-base-cd: calico-base-image-all
+	$(MAKE) BUILD_IMAGES=$(CALICO_BASE) cd-common
 
 # Calico builder which contains Go/Clang compilers and necessary utilities for UT/FVs.
 .PHONY: build
@@ -71,9 +73,7 @@ build:
 .PHONY: calico-go-build-image
 calico-go-build-image: register qemu-user-static-image build
 	$(DOCKER_BUILD) -t $(CALICO_GO_BUILD_ARCH_IMAGE) -f calico-go-build/Dockerfile calico-go-build/
-ifeq ($(ARCH),amd64)
-	docker tag $(CALICO_GO_BUILD_ARCH_IMAGE) $(CALICO_GO_BUILD_IMAGE)
-endif
+	$(MAKE) BUILD_IMAGES=$(CALICO_GO_BUILD) retag-build-images-with-registries VALIDARCHES=$(ARCH) LATEST_IMAGE_TAG=$(VERSION_TAG) IMAGETAG=$(VERSION_TAG)
 
 .PHONY: calico-go-build-image-all
 calico-go-build-image-all: $(addprefix sub-calico-go-build-image-,$(VALIDARCHES))
@@ -81,7 +81,8 @@ sub-calico-go-build-image-%:
 	$(MAKE) calico-go-build-image ARCH=$*
 
 .PHONY: calico-go-build-cd
-calico-go-build-cd: calico-go-build-image-all cd-common
+calico-go-build-cd: calico-go-build-image-all
+	$(MAKE) BUILD_IMAGES=$(CALICO_GO_BUILD) cd-common
 
 .PHONY: clean
 clean:
@@ -91,8 +92,6 @@ clean:
 	-docker image rm -f $$(docker images $(CALICO_GO_BUILD) -a -q)
 	-docker image rm -f $$(docker images $(QEMU_USER_STATIC) -a -q)
 
-.PHONY: cd
-cd: image-all cd-common
-
+.PHONY: cd-common
 cd-common: var-require-one-of-CONFIRM-DRYRUN var-require-all-BRANCH_NAME
 	$(MAKE) retag-build-images-with-registries push-images-to-registries push-manifests IMAGETAG=$(if $(IMAGETAG_PREFIX),$(IMAGETAG_PREFIX)-)$(BRANCH_NAME) EXCLUDEARCH="$(EXCLUDEARCH)"

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1,4 +1,6 @@
-VALIDARCHES = amd64 arm64 ppc64le s390x
+ARCHES = amd64 arm64 ppc64le s390x
+
+DEV_REGISTRIES ?= calico
 
 ifdef CI
     DOCKER_PROGRESS := --progress=plain


### PR DESCRIPTION
This change updates calico image push using the correct semaphore secret. It also moves the BUILD_IMAGES environment variables to Makefile targets.