### PR TITLE
Trigger calico/go-build auto pin update on successful tag builds

### DIFF
--- a/.semaphore/promotions/calico-go-build.yml
+++ b/.semaphore/promotions/calico-go-build.yml
@@ -42,7 +42,7 @@ blocks:
     dependencies:
       - Publish calico/go-build images
     run:
-      when: "branch = 'master' OR tag =~ '^1\\.\\d+\\.\\d-llvm\\d+\\.\\d\\.\\d-k8s1\\.\\d+\\.\\d'"
+      when: tag =~ '^1\\.\\d+\\.\\d-llvm\\d+\\.\\d\\.\\d-k8s1\\.\\d+\\.\\d'"
     task:
       secrets:
         - name: semaphore-api

--- a/.semaphore/promotions/calico-go-build.yml
+++ b/.semaphore/promotions/calico-go-build.yml
@@ -42,7 +42,7 @@ blocks:
     dependencies:
       - Publish calico/go-build images
     run:
-      when: tag =~ '^1\\.\\d+\\.\\d-llvm\\d+\\.\\d\\.\\d-k8s1\\.\\d+\\.\\d'"
+      when: "tag =~ '^1\\.\\d+\\.\\d-llvm\\d+\\.\\d\\.\\d-k8s1\\.\\d+\\.\\d'"
     task:
       secrets:
         - name: semaphore-api

--- a/Makefile.common
+++ b/Makefile.common
@@ -692,7 +692,7 @@ semaphore-run-auto-pin-update-workflow:
 # SEMAPHORE_AUTO_PIN_UPDATE_PROJECT_IDS.
 semaphore-run-auto-pin-update-workflows:
 	for ID in $(SEMAPHORE_AUTO_PIN_UPDATE_PROJECT_IDS); do\
-		SEMAPHORE_WORKFLOW_BRANCH=$(SEMAPHORE_GIT_BRANCH) SEMAPHORE_PROJECT_ID=$$ID $(MAKE) semaphore-run-auto-pin-update-workflow; \
+		SEMAPHORE_PROJECT_ID=$$ID $(MAKE) semaphore-run-auto-pin-update-workflow; \
 	done
 
 ###############################################################################


### PR DESCRIPTION
This changeset changes auto `calico/go-build` pin update to trigger only on successful tag builds. SEMAPHORE_WORKFLOW_BRANCH is also set to the master branch by default. Currently, it is always set to SEMAPHORE_GIT_BRANCH which isn't correct for tag builds.

Pick https://github.com/projectcalico/go-build/pull/627 and https://github.com/projectcalico/go-build/pull/629 into go1.23 release branch.