### PR TITLE
[go1.23] Fix git ls-remote tags pattern

### DIFF
--- a/.github/workflows/create-tag-on-version-change.yml
+++ b/.github/workflows/create-tag-on-version-change.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Create and push new tag (if not exists)
         run: |
           tag_name=${{ steps.generate-tag-name.outputs.tag_name }}
-          count=$(git ls-remote --tags origin "$tag_name" | grep -c "refs/tags/$tag_name" || :)
+          count=$(git ls-remote --tags --refs origin "$tag_name*" | grep -c "refs/tags/$tag_name" || :)
           if [ "$count" -gt 0 ] ; then
             echo "Git tag $tag_name already exists. Using new tag $tag_name-$count."
             tag_name="$tag_name-$count"


### PR DESCRIPTION
Pick https://github.com/projectcalico/go-build/pull/630 into go1.23 release branch.