### PR TITLE
Add protobuf-devel to calico/go-build

### DIFF
--- a/images/calico-go-build/Dockerfile
+++ b/images/calico-go-build/Dockerfile
@@ -59,7 +59,8 @@ RUN set -eux; \
     iproute-devel \
     iproute-tc \
     libbpf-devel \
-    llvm-${llvm_version}
+    llvm-${llvm_version} \
+    protobuf-devel
 
 RUN set -eux; \
     if [ "${TARGETARCH}" = "amd64" ]; then \


### PR DESCRIPTION
Install protobuf-devel package include protobuf well-known types like timestamp.proto. We need them to build felixbackend proto.