### PR TITLE
Update golang to v1.24.2 and k8s to v1.32.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectcalico/go-build
 
-go 1.23.2
+go 1.23.8
 
 require github.com/sirupsen/logrus v1.9.3
 

--- a/images/calico-go-build/Dockerfile
+++ b/images/calico-go-build/Dockerfile
@@ -7,9 +7,9 @@ FROM registry.access.redhat.com/ubi8/ubi:latest AS ubi
 ARG TARGETARCH
 
 ARG CONTAINERREGISTRY_VERSION=v0.20.3
-ARG CONTROLLER_TOOLS_VERSION=v0.16.5
-ARG GO_LINT_VERSION=v1.64.5
-ARG MOCKERY_VERSION=2.52.2
+ARG CONTROLLER_TOOLS_VERSION=v0.17.3
+ARG GO_LINT_VERSION=v1.64.8
+ARG MOCKERY_VERSION=2.52.3
 ARG YQ_VERSION=v4.45.1
 
 ENV PATH=/usr/local/go/bin:$PATH
@@ -163,18 +163,15 @@ RUN set -eux; \
 # Install ginkgo v2 as ginkgo2 and keep ginkgo v1 as ginkgo
 RUN set -eux; \
     k8s_libs_version=$(yq -r .kubernetes.version /etc/versions.yaml | sed 's/^1/0/'); \
-    go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.2 && mv /go/bin/ginkgo /go/bin/ginkgo2 && \
+    go install github.com/onsi/ginkgo/v2/ginkgo@v2.23.3 && mv /go/bin/ginkgo /go/bin/ginkgo2 && \
     go install github.com/onsi/ginkgo/ginkgo@v1.16.5 && \
     go install github.com/jstemmer/go-junit-report@v1.0.0 && \
-    go install github.com/mikefarah/yq/v3@3.4.1 && \
-    go install github.com/pmezard/licenses@v0.0.0-20160314180953-1117911df3df && \
-    go install github.com/swaggo/swag/cmd/swag@v1.16.4 && \
     go install github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad && \
-    go install golang.org/x/tools/cmd/goimports@v0.28.0 && \
-    go install golang.org/x/tools/cmd/stringer@v0.28.0 && \
+    go install golang.org/x/tools/cmd/goimports@v0.31.0 && \
+    go install golang.org/x/tools/cmd/stringer@v0.31.0 && \
     go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1 && \
-    go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.4 && \
-    go install gotest.tools/gotestsum@v1.12.0 && \
+    go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.6 && \
+    go install gotest.tools/gotestsum@v1.12.1 && \
     go install k8s.io/code-generator/cmd/client-gen@v${k8s_libs_version} && \
     go install k8s.io/code-generator/cmd/conversion-gen@v${k8s_libs_version} && \
     go install k8s.io/code-generator/cmd/deepcopy-gen@v${k8s_libs_version} && \

--- a/images/calico-go-build/versions.yaml
+++ b/images/calico-go-build/versions.yaml
@@ -1,12 +1,12 @@
 golang:
-  version: 1.24.1
+  version: 1.24.2
   checksum:
     sha256:
-      amd64: cb2396bae64183cdccf81a9a6df0aea3bce9511fc21469fb89a0c00470088073
-      arm64: 8df5750ffc0281017fb6070fba450f5d22b600a02081dceef47966ffaf36a3af
-      ppc64le: 0fb522efcefabae6e37e69bdc444094e75bfe824ea6d4cc3cbc70c7ae1b16858
-      s390x: 6c05e14d8f11094cb56a1c50f390b6b658bed8a7cbd8d1a57e926581b7eabfce
+      amd64: 68097bd680839cbc9d464a0edce4f7c333975e27a90246890e9f1078c7e702ad
+      arm64: 756274ea4b68fa5535eb9fe2559889287d725a8da63c6aae4d5f23778c229f4b
+      ppc64le: 5fff857791d541c71d8ea0171c73f6f99770d15ff7e2ad979104856d01f36563
+      s390x: 1cb3448166d6abb515a85a3ee5afbdf932081fb58ad7143a8fb666fbc06146d9
 kubernetes:
-  version: 1.32.2
+  version: 1.32.3
 llvm:
   version: 18.1.8


### PR DESCRIPTION
This changeset updates golang to v1.24.2 and k8s tools to v1.32.3. It also updates some dependent utilities.