### PR TITLE
Fix s390x dynamic loader symlink

### DIFF
--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -6,7 +6,8 @@ build: semvalidator-build-$(ARCH)
 
 .PHONY: semvalidator-build-$(ARCH)
 semvalidator-build-$(ARCH): semvalidator/main.go
-	CGO_ENABLED=0 go build -o bin/semvalidator-$(ARCH) -v -buildvcs=false -ldflags "-s -w" semvalidator/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) \
+		go build -o bin/semvalidator-$(ARCH) -v -buildvcs=false -ldflags "-s -w" semvalidator/main.go
 
 .PHONY: clean
 clean:

--- a/images/calico-base/Dockerfile.ubi8
+++ b/images/calico-base/Dockerfile.ubi8
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS ubi
 
 ARG LDSONAME
+ARG TARGETARCH
 
 RUN microdnf upgrade -y
 
@@ -9,11 +10,16 @@ RUN microdnf upgrade -y
 RUN mkdir -p /rootfs/lib64 /rootfs/etc
 
 # Copy dynamic loader and symbolic links.
+# For s390x architecture, modify the /lib/${LDSONAME} symlink to ../lib64/${LDSONAME}
+# instead of /usr/lib64 as the /usr/lib64 directory is not included in our base.
 RUN cp /lib64/ld-2.28.so /rootfs/lib64/ld-2.28.so
 RUN set -eux; \
     cp -a /lib64/${LDSONAME} /rootfs/lib64/${LDSONAME}; \
     if [ -f /lib/${LDSONAME} ]; then \
         mkdir -p /rootfs/lib && cp -a /lib/${LDSONAME} /rootfs/lib/${LDSONAME}; \
+        if [ "${TARGETARCH}" = "s390x" ]; then \
+            ln -sf ../lib64/${LDSONAME} /rootfs/lib/${LDSONAME}; \
+        fi \
     fi
 
 # Required external C dependencies for CGO builds.
@@ -36,6 +42,10 @@ RUN cp /etc/os-release /rootfs/etc/os-release
 FROM scratch AS source
 
 COPY --from=ubi /rootfs /
+
+# Verify if glibc can be properly loaded.
+# This check ensures that the dynamic loader and symbolic links are copied correctly.
+RUN ["/lib64/libc.so.6"]
 
 # tmp.tar has a /tmp with the correct permissions 01777.
 ADD tmp.tar /

--- a/images/calico-base/Dockerfile.ubi9
+++ b/images/calico-base/Dockerfile.ubi9
@@ -38,6 +38,10 @@ FROM scratch AS source
 
 COPY --from=ubi /rootfs /
 
+# Verify if glibc is properly loaded.
+# This check ensures that the dynamic loader and symbolic links are copied correctly.
+RUN ["/lib64/libc.so.6"]
+
 # tmp.tar has a /tmp with the correct permissions 01777.
 ADD tmp.tar /
 


### PR DESCRIPTION
This change resolves an issue with the s390x dynamic loader symlink. On s390x UBI 8, the symlink points to `/usr/lib64`. This directory is not included in the Calico base image, resulting a dangling symlink and preventing programs from loading. This update corrects the symlink and added a test to validate the minimum C runtime. It also fixes semvalidator multi-arch builds.