### PR TITLE
Use a docker volume for the go cache.

### DIFF
--- a/images/calico-go-build/Dockerfile
+++ b/images/calico-go-build/Dockerfile
@@ -211,3 +211,5 @@ ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
 COPY --from=ubi / /
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+VOLUME /caches

--- a/images/calico-go-build/entrypoint.sh
+++ b/images/calico-go-build/entrypoint.sh
@@ -5,8 +5,20 @@
 
 USER_ID=${LOCAL_USER_ID:-9001}
 
+# Make sure the cache directories exist.  We use /tmp-like permissions to
+# allow all users to create files in there.
+mkdir -p /caches/go-build-cache
+mkdir -p /caches/go-mod-cache
+chmod 1777 /caches/go-build-cache
+chmod 1777 /caches/go-mod-cache
+
 if [ "${RUN_AS_ROOT}" = "true" ]; then
+  export GOCACHE=/caches/go-build-cache/root
+  export GOMODCACHE=/caches/go-mod-cache/root
   exec "$@"
+else  
+  export GOCACHE=/caches/go-build-cache/$USER_ID
+  export GOMODCACHE=/caches/go-mod-cache/$USER_ID
 fi
 
 echo "Starting with UID: $USER_ID" 1>&2


### PR DESCRIPTION
- Permissions like a tmp dir to allow anyone to write.
- Use individual GOCACHE for each user (in practice, just keeps root and the main user separate).
- Do same for GOMODCACHE.

Needs corresponding changes to the monorepo build to 

- Remove the old direcctory/add the volume:
```
--mount type=volume,source=go-pkg-cache,target=/caches
```
- Remove creation of the `.go-pkg-cache` dir
- Cache the cache in CI.