### PR TITLE
add gcloud and docker-credential-gcr for using docker credHelper

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -98,6 +98,9 @@ PUSH_MANIFEST_IMAGES := $(foreach registry,$(MANIFEST_REGISTRIES),$(foreach imag
 # location of docker credentials to push manifests
 DOCKER_CONFIG ?= $(HOME)/.docker/config.json
 
+# location of gcloud config
+GCLOUD_CONFIG ?= $(HOME)/.config/gcloud
+
 # If a repository still relies on vendoring, it must set GOMOD_VENDOR to "true".
 # If that's not the case and we're running in CI, set -mod=readonly to prevent builds
 # from being flagged as dirty due to updates in go.mod or go.sum _except_ for:
@@ -387,7 +390,7 @@ git-commit:
 # different implementation.
 ###############################################################################
 
-CRANE_CMD         = docker run -e LOCAL_USER_ID=$(LOCAL_USER_ID) -v $(DOCKER_CONFIG):/home/user/.docker/config.json $(CALICO_BUILD) crane
+CRANE_CMD         = docker run -e LOCAL_USER_ID=$(LOCAL_USER_ID) -v $(DOCKER_CONFIG):/home/user/.docker/config.json -v $(GCLOUD_CONFIG):/home/user/.config/gcloud $(CALICO_BUILD) crane
 GIT_CMD           = git
 DOCKER_CMD        = docker
 

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -1,14 +1,20 @@
 include ../lib.Makefile
 include ../Makefile.common
 
-.PHONY: build
-build: semvalidator-build-$(ARCH)
+PACKAGE_NAME := github.com/projectcalico/go-build
+VERSION := $(shell git describe --tags --dirty --always --abbrev=12)
+REVISION := $(shell git rev-parse --short HEAD)
 
-.PHONY: semvalidator-build-$(ARCH)
-semvalidator-build-$(ARCH): semvalidator/main.go
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) \
-		go build -o bin/semvalidator-$(ARCH) -v -buildvcs=false -ldflags "-s -w" semvalidator/main.go
+.PHONY: build
+build: build-semvalidator-$(ARCH) build-docker-credential-calieph-$(ARCH)
 
 .PHONY: clean
 clean:
 	rm -fr bin/
+
+.PHONY: build-%-$(ARCH)
+build-%-$(ARCH): %/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) \
+		go build -o bin/$*-$(ARCH) -v -buildvcs=false \
+		-ldflags="-s -w -X '$(PACKAGE_NAME)/cmd/$*.Revision=$(REVISION)' -X '$(PACKAGE_NAME)/cmd/$*.Version=$(VERSION)'" \
+		$*/main.go

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,12 @@ module github.com/projectcalico/go-build
 
 go 1.23.8
 
-require github.com/sirupsen/logrus v1.9.3
+require (
+	github.com/sirupsen/logrus v1.9.3
+	golang.org/x/oauth2 v0.30.0
+)
 
-require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+require (
+	cloud.google.com/go/compute/metadata v0.3.0 // indirect
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
+cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -8,6 +10,8 @@ github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVs
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
+golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/images/Makefile
+++ b/images/Makefile
@@ -46,7 +46,7 @@ calico-base-cd: calico-base-image-all var-require-one-of-CONFIRM-DRYRUN var-requ
 build:
 	$(MAKE) -C ../cmd build
 	mkdir -p calico-go-build/bin/
-	cp ../cmd/bin/semvalidator-$(ARCH) calico-go-build/bin/semvalidator-$(ARCH)
+	cp ../cmd/bin/* calico-go-build/bin/
 
 CALICO_GO_BUILD_IMAGETAG ?= latest
 

--- a/images/calico-go-build/Dockerfile
+++ b/images/calico-go-build/Dockerfile
@@ -6,6 +6,7 @@ FROM registry.access.redhat.com/ubi8/ubi:latest AS ubi
 
 ARG TARGETARCH
 
+ARG DOCKER_CREDHELPER_GCR_VERSION=v2.1.30
 ARG CONTAINERREGISTRY_VERSION=v0.20.6
 ARG CONTROLLER_TOOLS_VERSION=v0.18.0
 ARG GO_LINT_VERSION=v2.3.1
@@ -35,6 +36,39 @@ RUN dnf upgrade -y && dnf install -y \
     wget \
     xz \
     zip
+
+# Install Google Cloud SDK for GCR/GAR
+RUN cat <<EOM > /etc/yum.repos.d/google-cloud-sdk.repo
+[google-cloud-cli]
+name=Google Cloud CLI
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOM
+RUN <<EOF
+dnf install libxcrypt-compat.x86_64 -y
+dnf install google-cloud-cli -y
+EOF
+# Install standalone credential helper for Google Container Registry
+RUN <<EOF
+case "${TARGETARCH}" in
+  amd64)
+    curl -sfL https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/${DOCKER_CREDHELPER_GCR_VERSION}/docker-credential-gcr_linux_amd64-${DOCKER_CREDHELPER_GCR_VERSION#v}.tar.gz | tar xz -C /usr/local/bin docker-credential-gcr
+    ;;
+  arm64)
+    curl -sfL https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/${DOCKER_CREDHELPER_GCR_VERSION}/docker-credential-gcr_linux_arm64-${DOCKER_CREDHELPER_GCR_VERSION#v}.tar.gz | tar xz -C /usr/local/bin docker-credential-gcr
+    ;;
+  s390x)
+    curl -sfL https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/${DOCKER_CREDHELPER_GCR_VERSION}/docker-credential-gcr_linux_s390x-${DOCKER_CREDHELPER_GCR_VERSION#v}.tar.gz | tar xz -C /usr/local/bin docker-credential-gcr
+    ;;
+  *)
+    echo >&2 "error: unsupported architecture '${TARGETARCH}'"
+    exit 1
+    ;;
+esac
+EOF
 
 # Install yq and copy versions.yaml
 RUN curl -sfL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${TARGETARCH} -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
@@ -198,6 +232,8 @@ COPY --from=bpftool /bpftool /usr/bin
 
 # Copy semvalidator release tool.
 COPY bin/semvalidator-${TARGETARCH} /usr/local/bin/semvalidator
+# Copy docker-credential-calieph tool.
+COPY bin/docker-credential-calieph-${TARGETARCH} /usr/local/bin/docker-credential-calieph
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 


### PR DESCRIPTION
This allow using docker credential helper for GCR/GAR.

There are 2 ways to use credential helper for GCR/GAR - gcloud CLI or docker-credential-gcr (standalone). This adds both libraries. This will require modifying the usage of go-build in the code to also mount the gcloud config.

```sh
docker run -t --entrypoint /bin/sh -v $(DOCKER_CONFIG):/root/.docker/config.json -v $(GCLOUD_CONFIG):/root/.config/gcloud go-build -c "crane cp SRC DST"
```