### PR TITLE
[go1.25] Auto-update Go/Kubernetes versions

### DIFF
--- a/images/calico-go-build/versions.yaml
+++ b/images/calico-go-build/versions.yaml
@@ -7,6 +7,6 @@ golang:
       ppc64le: b0c41c7da1fc8d39020d65296a0dc54167afd9f76d67064e22c31ce3d839a739
       s390x: 0cf55136ac7eaccfc36d849054f849510ea289c2d959ffbed7b3866b4f484d17
 kubernetes:
-  version: 1.35.3
+  version: 1.35.4
 llvm:
   version: 18.1.8


### PR DESCRIPTION
Automated version update for `go1.25`:

Kubernetes: 1.35.3 -> 1.35.4