### PR TITLE
[draft] feat(go-build): explore TinyGo for wasm build targets

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -71,6 +71,27 @@ blocks:
           matrix:
             - env_var: ARCH
               values: ["amd64", "arm64", "ppc64le", "s390x"]
+        - name: TinyGo wasm-smoke compile
+          commands:
+            - |
+              if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "arm64" ]; then
+                docker run --rm \
+                  -v "$(pwd)/images/calico-go-build/test/wasm-smoke:/src" \
+                  -w /src \
+                  calico/go-build:${CALICO_GO_BUILD_IMAGETAG}-${ARCH} \
+                  sh -c 'go mod download && \
+                    tinygo build \
+                      -target=wasip1 \
+                      -gc=custom -opt=2 -scheduler=none \
+                      -tags="custommalloc nottinygc_envoy" \
+                      -o /tmp/smoke.wasm . && \
+                    file /tmp/smoke.wasm | grep -q "WebAssembly"'
+              else
+                echo "TinyGo not installed on ${ARCH}; skipping wasm-smoke"
+              fi
+          matrix:
+            - env_var: ARCH
+              values: ["amd64", "arm64", "ppc64le", "s390x"]
 
   - name: calico/rust-build image
     dependencies: []

--- a/images/calico-go-build/Dockerfile
+++ b/images/calico-go-build/Dockerfile
@@ -181,8 +181,19 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 # Install TinyGo for WebAssembly builds (amd64+arm64 only — upstream does not
 # ship ppc64le/s390x binaries; wasm output is arch-agnostic so a single host
 # arch suffices for any consumer).
+#
+# TinyGo 0.37+ release binaries link against GCC 12+ libstdc++ which requires
+# GLIBCXX_3.4.30. AlmaLinux 9's default libstdc++ comes from GCC 11 and tops
+# out at GLIBCXX_3.4.29, so we install gcc-toolset-13-libstdc++-devel from
+# CRB and add its lib path to the dynamic linker config. Forward-compat ABI
+# means binaries needing older GLIBCXX still resolve correctly.
+# TODO: drop this gcc-toolset-13 install once go-build base moves to
+# AlmaLinux 10 (ships GCC 14 + GLIBCXX_3.4.32+ natively).
 RUN set -eux; \
     if [ "${TARGETARCH}" = "amd64" ] || [ "${TARGETARCH}" = "arm64" ]; then \
+        dnf --enablerepo=crb install -y gcc-toolset-13-libstdc++-devel; \
+        echo "/opt/rh/gcc-toolset-13/root/usr/lib64" > /etc/ld.so.conf.d/gcc-toolset-13.conf; \
+        ldconfig; \
         tinygo_version=$(yq -r .tinygo.version /etc/versions.yaml); \
         tinygo_sha256=$(yq -r ".tinygo.checksum.sha256.${TARGETARCH}" /etc/versions.yaml); \
         wget -q -O /tmp/tinygo.tar.gz \
@@ -191,7 +202,6 @@ RUN set -eux; \
         tar -C /usr/local -xzf /tmp/tinygo.tar.gz; \
         rm /tmp/tinygo.tar.gz; \
     fi
-ENV PATH=/usr/local/tinygo/bin:$PATH
 
 # su-exec is used by the entrypoint script to execute the user's command with the right UID/GID.
 RUN set -eux; \
@@ -303,7 +313,7 @@ ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
 ENV CC=clang
 ENV CXX=clang++
-ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+ENV PATH=$GOPATH/bin:/usr/local/go/bin:/usr/local/tinygo/bin:$PATH
 
 COPY --from=builder / /
 

--- a/images/calico-go-build/Dockerfile
+++ b/images/calico-go-build/Dockerfile
@@ -182,10 +182,30 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 # ship ppc64le/s390x binaries; wasm output is arch-agnostic so a single host
 # arch suffices for any consumer).
 #
-# Pin tracks versions.yaml `tinygo.version`. See that file for the constraint
-# narrative around AlmaLinux 9's libstdc++ (GCC 11) and the 0.34.0 ceiling.
+# Two-step install: (1) bundle a newer libstdc++.so.6 from Debian trixie
+# because AlmaLinux 9's system libstdc++ (GCC 11, GLIBCXX_3.4.29) is too old
+# for TinyGo 0.37+ binaries (need GLIBCXX_3.4.30+); (2) extract the upstream
+# TinyGo release tarball into /usr/local. See versions.yaml `tinygo:` block
+# for the rationale and the bump path to AlmaLinux 10.
 RUN set -eux; \
     if [ "${TARGETARCH}" = "amd64" ] || [ "${TARGETARCH}" = "arm64" ]; then \
+        case "${TARGETARCH}" in \
+            amd64) deb_arch_dir=x86_64-linux-gnu ;; \
+            arm64) deb_arch_dir=aarch64-linux-gnu ;; \
+        esac; \
+        libstdcpp_deb_ver=$(yq -r .tinygo.libstdcpp.deb_version /etc/versions.yaml); \
+        libstdcpp_sha256=$(yq -r ".tinygo.libstdcpp.sha256.${TARGETARCH}" /etc/versions.yaml); \
+        wget -q -O /tmp/libstdcpp6.deb \
+            "http://deb.debian.org/debian/pool/main/g/gcc-14/libstdc++6_${libstdcpp_deb_ver}_${TARGETARCH}.deb"; \
+        echo "${libstdcpp_sha256}  /tmp/libstdcpp6.deb" | sha256sum -c -; \
+        mkdir -p /tmp/libstdcpp-extract; \
+        cd /tmp/libstdcpp-extract; \
+        ar x /tmp/libstdcpp6.deb; \
+        tar -xf data.tar.*; \
+        cp ./usr/lib/${deb_arch_dir}/libstdc++.so.6.0.* /usr/lib64/; \
+        cd /; \
+        rm -rf /tmp/libstdcpp6.deb /tmp/libstdcpp-extract; \
+        ldconfig; \
         tinygo_version=$(yq -r .tinygo.version /etc/versions.yaml); \
         tinygo_sha256=$(yq -r ".tinygo.checksum.sha256.${TARGETARCH}" /etc/versions.yaml); \
         wget -q -O /tmp/tinygo.tar.gz \

--- a/images/calico-go-build/Dockerfile
+++ b/images/calico-go-build/Dockerfile
@@ -178,6 +178,21 @@ ENV GOPATH=/go
 ENV PATH=$GOPATH/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 
+# Install TinyGo for WebAssembly builds (amd64+arm64 only — upstream does not
+# ship ppc64le/s390x binaries; wasm output is arch-agnostic so a single host
+# arch suffices for any consumer).
+RUN set -eux; \
+    if [ "${TARGETARCH}" = "amd64" ] || [ "${TARGETARCH}" = "arm64" ]; then \
+        tinygo_version=$(yq -r .tinygo.version /etc/versions.yaml); \
+        tinygo_sha256=$(yq -r ".tinygo.checksum.sha256.${TARGETARCH}" /etc/versions.yaml); \
+        wget -q -O /tmp/tinygo.tar.gz \
+            "https://github.com/tinygo-org/tinygo/releases/download/v${tinygo_version}/tinygo${tinygo_version}.linux-${TARGETARCH}.tar.gz"; \
+        echo "${tinygo_sha256}  /tmp/tinygo.tar.gz" | sha256sum -c -; \
+        tar -C /usr/local -xzf /tmp/tinygo.tar.gz; \
+        rm /tmp/tinygo.tar.gz; \
+    fi
+ENV PATH=/usr/local/tinygo/bin:$PATH
+
 # su-exec is used by the entrypoint script to execute the user's command with the right UID/GID.
 RUN set -eux; \
     curl -sfL https://raw.githubusercontent.com/ncopa/su-exec/master/su-exec.c -o /tmp/su-exec.c; \

--- a/images/calico-go-build/Dockerfile
+++ b/images/calico-go-build/Dockerfile
@@ -182,18 +182,10 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 # ship ppc64le/s390x binaries; wasm output is arch-agnostic so a single host
 # arch suffices for any consumer).
 #
-# TinyGo 0.37+ release binaries link against GCC 12+ libstdc++ which requires
-# GLIBCXX_3.4.30. AlmaLinux 9's default libstdc++ comes from GCC 11 and tops
-# out at GLIBCXX_3.4.29, so we install gcc-toolset-13-libstdc++-devel from
-# CRB and add its lib path to the dynamic linker config. Forward-compat ABI
-# means binaries needing older GLIBCXX still resolve correctly.
-# TODO: drop this gcc-toolset-13 install once go-build base moves to
-# AlmaLinux 10 (ships GCC 14 + GLIBCXX_3.4.32+ natively).
+# Pin tracks versions.yaml `tinygo.version`. See that file for the constraint
+# narrative around AlmaLinux 9's libstdc++ (GCC 11) and the 0.34.0 ceiling.
 RUN set -eux; \
     if [ "${TARGETARCH}" = "amd64" ] || [ "${TARGETARCH}" = "arm64" ]; then \
-        dnf --enablerepo=crb install -y gcc-toolset-13-libstdc++-devel; \
-        echo "/opt/rh/gcc-toolset-13/root/usr/lib64" > /etc/ld.so.conf.d/gcc-toolset-13.conf; \
-        ldconfig; \
         tinygo_version=$(yq -r .tinygo.version /etc/versions.yaml); \
         tinygo_sha256=$(yq -r ".tinygo.checksum.sha256.${TARGETARCH}" /etc/versions.yaml); \
         wget -q -O /tmp/tinygo.tar.gz \

--- a/images/calico-go-build/versions.yaml
+++ b/images/calico-go-build/versions.yaml
@@ -11,15 +11,23 @@ kubernetes:
 llvm:
   version: 20.1.8
 tinygo:
-  # Pinned to 0.34.0 — last release that runs against AlmaLinux 9's default
-  # libstdc++ (GCC 11, max GLIBCXX_3.4.29). TinyGo 0.37+ release binaries
-  # require GLIBCXX_3.4.30+ (GCC 12+). RHEL 9 ABI-freezes libstdc++ at the
-  # 11.X series — no newer libstdc++.so.6 runtime is shipped via official
-  # rpms (gcc-toolset-N packages ship dev/static libs only, no .so.6
-  # runtime). Bump path: AlmaLinux 10 base (ships GCC 14) unblocks newer
-  # TinyGo natively.
-  version: 0.34.0
+  version: 0.41.1
   checksum:
     sha256:
-      amd64: 8acd27a39090e1e5c3ca341e81350f813ec6a02bf8090c4fc7c4b1afd4186341
-      arm64: a84b5134dc5144a494e3b7e78579536aca34c77951ddd0b19c300209d8b541e1
+      amd64: e156d1d93a376eef639a4143d13be07e8c463fb6cf2d7d447698ed4474d23e91
+      arm64: 789733bc3b5bace0bd1835a267b3ea267804a7ef1cfe69bc522c295f5226d624
+  # libstdc++.so.6 runtime bundled from Debian trixie because AlmaLinux 9
+  # (RHEL ABI freeze) caps the system libstdc++ at GCC 11 / GLIBCXX_3.4.29.
+  # TinyGo 0.37+ release binaries are built against GCC 12+ and require
+  # GLIBCXX_3.4.30+ at runtime. AlmaLinux 9's gcc-toolset-N rpms ship
+  # dev/static libs only — no libstdc++.so.6 runtime — so installing them
+  # does not solve the problem. Forward-compat ABI guarantees: newer
+  # libstdc++.so.6 satisfies older GLIBCXX symbols, so dropping a 14.x
+  # libstdc++ in /usr/lib64 is safe for all consumers.
+  # Bump path: when go-build base moves to AlmaLinux 10 (ships GCC 14
+  # natively, GLIBCXX_3.4.32+), drop this Debian-bundled libstdc++.
+  libstdcpp:
+    deb_version: 14.2.0-19
+    sha256:
+      amd64: ab1fa05837aa7a92aae748fd07a18a35f7d18bb4a71c4724fe2bbf0e32089de0
+      arm64: 6669b0c52a2e7c6af9adfdabce3ff6e286065cdfbc7b85280862b5f799daebee

--- a/images/calico-go-build/versions.yaml
+++ b/images/calico-go-build/versions.yaml
@@ -10,3 +10,9 @@ kubernetes:
   version: 1.35.4
 llvm:
   version: 20.1.8
+tinygo:
+  version: 0.41.1
+  checksum:
+    sha256:
+      amd64: e156d1d93a376eef639a4143d13be07e8c463fb6cf2d7d447698ed4474d23e91
+      arm64: 789733bc3b5bace0bd1835a267b3ea267804a7ef1cfe69bc522c295f5226d624

--- a/images/calico-go-build/versions.yaml
+++ b/images/calico-go-build/versions.yaml
@@ -11,8 +11,15 @@ kubernetes:
 llvm:
   version: 20.1.8
 tinygo:
-  version: 0.41.1
+  # Pinned to 0.34.0 — last release that runs against AlmaLinux 9's default
+  # libstdc++ (GCC 11, max GLIBCXX_3.4.29). TinyGo 0.37+ release binaries
+  # require GLIBCXX_3.4.30+ (GCC 12+). RHEL 9 ABI-freezes libstdc++ at the
+  # 11.X series — no newer libstdc++.so.6 runtime is shipped via official
+  # rpms (gcc-toolset-N packages ship dev/static libs only, no .so.6
+  # runtime). Bump path: AlmaLinux 10 base (ships GCC 14) unblocks newer
+  # TinyGo natively.
+  version: 0.34.0
   checksum:
     sha256:
-      amd64: e156d1d93a376eef639a4143d13be07e8c463fb6cf2d7d447698ed4474d23e91
-      arm64: 789733bc3b5bace0bd1835a267b3ea267804a7ef1cfe69bc522c295f5226d624
+      amd64: 8acd27a39090e1e5c3ca341e81350f813ec6a02bf8090c4fc7c4b1afd4186341
+      arm64: a84b5134dc5144a494e3b7e78579536aca34c77951ddd0b19c300209d8b541e1


### PR DESCRIPTION
## Status: DRAFT / RFC - asking for your advice

This PR does not work yet. I'm posting it because I'm stuck and I want your input before I keep trying.

## What I want to do

Add TinyGo to `calico/go-build`. Then `calico-private/gateway/coraza-wasm/` can stop using the upstream `tinygo/tinygo:0.34.0` image and use our toolchain image instead.

Full design + plan (in another repo):
- Design: [`docs/planning/2026-04-30-tinygo-toolchain-migration-design.md`](https://github.com/tigera/gateway-extensions-controller/blob/main/docs/planning/2026-04-30-tinygo-toolchain-migration-design.md) - see §13 for the long version of what's below.
- Plan: [`docs/planning/2026-04-30-tinygo-toolchain-migration-plan.md`](https://github.com/tigera/gateway-extensions-controller/blob/main/docs/planning/2026-04-30-tinygo-toolchain-migration-plan.md).

## What I tried (4 things, all failed)

The 6 commits in this PR walk through each attempt. Each commit message has the full detail.

1. **Install TinyGo 0.41 from upstream tarball.** Failed: TinyGo 0.41 needs `GLIBCXX_3.4.30`. AlmaLinux 9 only has up to `GLIBCXX_3.4.29` (it ships GCC 11).

2. **Install `gcc-toolset-13-libstdc++-devel` from CRB.** Failed: that rpm only has dev/static files. No `libstdc++.so.6` runtime is shipped in any gcc-toolset rpm. I checked all of them.

3. **Pin TinyGo to 0.34 (last AL9-compatible version).** Failed: TinyGo 0.34 only supports Go up to 1.23. `calico/go-build` has Go 1.26. TinyGo refuses to run.

4. **Bundle libstdc++ from Debian trixie.** Failed: the Debian libstdc++ needs glibc 2.36+. AlmaLinux 9 has glibc 2.34. Can't fix glibc without replacing the OS base.

CI on this PR fails at the `su-exec` build step (commit `c669709`). That's the wall.

## Three options I see

1. **Move `calico/go-build` to AlmaLinux 10.** AL10 has glibc 2.39 + GCC 14, TinyGo 0.41 just works, no workarounds. Big change for the whole team.

2. **Two variants: AL9 and AL10.** Same pattern `calico-base` already uses (`UBI_VERSIONS ?= ubi9 ubi10`). The plugin uses ubi10. Other components stay on ubi9 until they are ready. Unblocks the plugin without forcing everyone.

3. **New image: `calico/wasm-build` on AL10.** Just for wasm. Small change. But it adds one more image.

## What I want to ask you

1. Is AL9 .. AL10 already on the toolchain roadmap? When?
2. Is UBI 10 / AL10 ready from the supply chain side?
3. Would you accept option 2 (two variants) as a temporary step?
4. Did I miss something? Maybe a `dnf module` trick to get newer libstdc++ on AL9?
5. The plugin is staying on `tinygo/tinygo:0.34.0` for now - is that OK with you while we figure this out?

Thanks!