### PR TITLE
[PICK #819] Add scripts needed for checking out a repo in argo ci

### DIFF
--- a/images/calico-go-build/Dockerfile
+++ b/images/calico-go-build/Dockerfile
@@ -279,6 +279,13 @@ COPY ssh_known_hosts /etc/ssh/ssh_known_hosts
 # Copy semvalidator release tool.
 COPY bin/semvalidator-${TARGETARCH} /usr/local/bin/semvalidator
 
+# Install Argo CI helper scripts so this image can serve as the base for Argo
+# workflows, which have no pre-checkout step. Semaphore runners do their own
+# checkout and ignore these.
+COPY scripts/checkout.sh /usr/local/bin/checkout
+COPY scripts/setup-github-ssh.sh /usr/local/bin/setup-github-ssh
+COPY scripts/create-local-secret.sh /usr/local/bin/create-local-secret
+
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Squash into a single layer

--- a/images/calico-go-build/scripts/checkout.sh
+++ b/images/calico-go-build/scripts/checkout.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+
+source setup-github-ssh
+
+# clone repo and checkout branch if required
+git clone ${CI_GIT_URL} ${CI_GIT_DIR}
+cd ${CI_GIT_DIR}
+if [ "${CI_GIT_CLONED_BRANCH}" != "" ]; then
+    echo "[INFO] Checking out branch ${CI_GIT_CLONED_BRANCH}"
+    git checkout ${CI_GIT_CLONED_BRANCH}
+fi
+if [ "${CI_GIT_SHA}" != "" ]; then
+    echo "[INFO] Checking out commit ${CI_GIT_SHA}"
+    git checkout ${CI_GIT_SHA}
+else
+    echo "[WARN] CI_GIT_SHA env var is empty - not running on exact commit"
+fi

--- a/images/calico-go-build/scripts/create-local-secret.sh
+++ b/images/calico-go-build/scripts/create-local-secret.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+# Restrict permissions on any file/dir we create so the secret is never briefly
+# world-readable between write and chmod.
+umask 077
+
+__secretname=$1
+__secretpath=$2
+if printenv "${__secretname}" > /dev/null; then
+    mkdir -p "$(dirname "${__secretpath}")"
+    printenv "${__secretname}" > "${__secretpath}"
+    echo "Created secret file at ${__secretpath}"
+else
+    echo "Secret ${__secretname} not created as env var not found"
+fi

--- a/images/calico-go-build/scripts/setup-github-ssh.sh
+++ b/images/calico-go-build/scripts/setup-github-ssh.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+# github.com host keys are pre-installed at /etc/ssh/ssh_known_hosts (see Dockerfile),
+# so no runtime ssh-keyscan is needed.
+
+mkdir -p ~/.keys
+
+eval "$(ssh-agent -s)"
+create-local-secret "marvin" "${HOME}/.keys/marvin"
+
+chmod 0600 ~/.keys/*
+ssh-add ~/.keys/*


### PR DESCRIPTION
Adding these scripts makes it easier to use the go-build as the base image for the argo ci runs.

The motifivation is that we're currently using a custom ubuntu image with Dind so we can run go-build, but it would be better to just run the go-build image as the argo ci base image.