### PR TITLE
[PICK #820] Trigger create-tag workflow on push instead of pull_request close

### DIFF
--- a/.github/workflows/create-branch-on-go-version-change.yml
+++ b/.github/workflows/create-branch-on-go-version-change.yml
@@ -1,16 +1,13 @@
 name: Create new Git branch on Go compiler version change
 
 on:
-  # create a new go1.x branch and a release tag when changes are merged to the master branch
-  pull_request:
-    types:
-      - closed
+  # create a new go1.x branch and a release tag when changes land on the master branch
+  push:
     branches:
       - master
 
 jobs:
   create-branch:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/create-tag-on-version-change.yml
+++ b/.github/workflows/create-tag-on-version-change.yml
@@ -1,16 +1,13 @@
 name: Create new Git tag on compiler version change
 
 on:
-  # create a new release tag when changes are merged to the go1.x release branches
-  pull_request:
-    types:
-      - closed
+  # create a new release tag when changes land on the go1.x release branches
+  push:
     branches:
       - go1.*
 
 jobs:
   create-tag:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
  The previous trigger (pull_request: closed with merged == true) does not
  work reliably for PRs from forks:

    - GitHub downgrades GITHUB_TOKEN to read-only for fork-triggered runs, regardless of the workflow's permissions block. The git push of the new tag fails with 403.
    - Fork PR workflows can be gated behind manual approval (Settings → Actions → "Fork pull request workflows from outside collaborators"), in which case the run never fires unless someone approves it.
    - Secrets are not exposed to fork PR runs.

  Switching to a push event on the go1.* branches sidesteps all three:
  once the merge commit lands on the base branch, the run is no longer
  "from a fork" — it executes in the upstream repo's context with the
  full permissions declared in the workflow. This matches how every other
  release-tagging workflow in the org is wired.

  The merged == true guard is dropped along with pull_request, since
  push events don't carry that field. Direct pushes to go1.* branches
  will now also trigger the workflow, which is acceptable because tag
  creation is idempotent (the workflow already handles the
  "tag already exists" case by appending -N).

  The changed file: .github/workflows/create-tag-on-version-change.yml — pull_request: closed → push, dropped the merged == true guard, kept the go1.* branch filter.