### PR TITLE
[go1.25] Auto-update Go/Kubernetes versions

### DIFF
--- a/images/calico-go-build/versions.yaml
+++ b/images/calico-go-build/versions.yaml
@@ -7,6 +7,6 @@ golang:
       ppc64le: 778925fdcdf9a272f823d147fad51545c3334b7ccd8652b2ccaaf2b01800280a
       s390x: 936b953e43921a64c12da871f76871ebbeb6d2092a7b8bdc307f5246f3c662cc
 kubernetes:
-  version: 1.35.4
+  version: 1.35.5
 llvm:
   version: 18.1.8


### PR DESCRIPTION
Automated version update for `go1.25`:

Kubernetes: 1.35.4 -> 1.35.5