### PR TITLE
[go1.26][Pick] Update k8s version in calico-go-build: 1.35.5 -> 1.36.1 (#838)

### DIFF
--- a/images/calico-go-build/versions.yaml
+++ b/images/calico-go-build/versions.yaml
@@ -7,6 +7,6 @@ golang:
       ppc64le: dbd82b50530ead2beb1fd72215117380df3cb16332b51467116dc35b3691dd75
       s390x: 5c0605b7175449f1c8e8cb02efaba2695caab914fad4dcedc764c2f4c6dfe6ca
 kubernetes:
-  version: 1.35.5
+  version: 1.36.1
 llvm:
   version: 20.1.8


### PR DESCRIPTION
Cherry-pick from master to bump Kubernetes from 1.35.5 to 1.36.1.
Created the go1.26-k8s1.35 release branch beforehand to preserve that combination.