### PR TITLE
Update LLVM in calico-go-build: 20.1.8 -> 21.1.8

### DIFF
--- a/images/calico-go-build/Dockerfile
+++ b/images/calico-go-build/Dockerfile
@@ -82,10 +82,13 @@ RUN set -eux; \
                 --repo="alma-${arch}-baseos" \
                 --repo="alma-${arch}-appstream" \
                 --repo="alma-${arch}-crb" \
+                --setopt="alma-${arch}-baseos.mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/baseos" \
                 --setopt="alma-${arch}-baseos.gpgcheck=1" \
                 --setopt="alma-${arch}-baseos.gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-9" \
+                --setopt="alma-${arch}-appstream.mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/appstream" \
                 --setopt="alma-${arch}-appstream.gpgcheck=1" \
                 --setopt="alma-${arch}-appstream.gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-9" \
+                --setopt="alma-${arch}-crb.mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/crb" \
                 --setopt="alma-${arch}-crb.gpgcheck=1" \
                 --setopt="alma-${arch}-crb.gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-9" \
                 --forcearch="${arch}" \

--- a/images/calico-go-build/versions.yaml
+++ b/images/calico-go-build/versions.yaml
@@ -9,4 +9,4 @@ golang:
 kubernetes:
   version: 1.36.1
 llvm:
-  version: 20.1.8
+  version: 21.1.8


### PR DESCRIPTION
AlmaLinux 9 rolled from 9.7 to 9.8 and dropped clang/lld/llvm 20.1.8 from the appstream repo; the only version available now is 21.1.8. This broke the calico-go-build image build on master with:
  Error: Unable to find a match: clang-20.1.8 lld-20.1.8 llvm-20.1.8

(Replaces #840, which closed automatically when the head branch was renamed.)