### PR TITLE
[go1.26] Fix missing s390x headers in go-build image

### DIFF
--- a/images/calico-go-build/Dockerfile
+++ b/images/calico-go-build/Dockerfile
@@ -87,10 +87,13 @@ RUN set -eux; \
                 --repo="alma-${arch}-baseos" \
                 --repo="alma-${arch}-appstream" \
                 --repo="alma-${arch}-crb" \
+                --setopt="alma-${arch}-baseos.mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/baseos" \
                 --setopt="alma-${arch}-baseos.gpgcheck=1" \
                 --setopt="alma-${arch}-baseos.gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-9" \
+                --setopt="alma-${arch}-appstream.mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/appstream" \
                 --setopt="alma-${arch}-appstream.gpgcheck=1" \
                 --setopt="alma-${arch}-appstream.gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-9" \
+                --setopt="alma-${arch}-crb.mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/crb" \
                 --setopt="alma-${arch}-crb.gpgcheck=1" \
                 --setopt="alma-${arch}-crb.gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-9" \
                 --forcearch="${arch}" \

--- a/images/calico-go-build/Dockerfile
+++ b/images/calico-go-build/Dockerfile
@@ -74,6 +74,12 @@ RUN set -eux; \
             sysroot="/usr/${triple}/sys-root"; \
             mkdir -p "${sysroot}"; \
             tmpdir=$(mktemp -d); \
+            # Base packages for all architectures
+            packages="gcc libgcc glibc glibc-devel kernel-headers elfutils-libelf elfutils-libelf-devel libpcap libpcap-devel zlib zlib-devel"; \
+            # Add s390x-specific packages
+            if [ "${arch}" = "s390x" ]; then \
+                packages="${packages} glibc-headers"; \
+            fi; \
             dnf download --destdir="${tmpdir}" \
                 --repofrompath="alma-${arch}-baseos,https://repo.almalinux.org/almalinux/9/BaseOS/${arch}/os/" \
                 --repofrompath="alma-${arch}-appstream,https://repo.almalinux.org/almalinux/9/AppStream/${arch}/os/" \
@@ -88,12 +94,7 @@ RUN set -eux; \
                 --setopt="alma-${arch}-crb.gpgcheck=1" \
                 --setopt="alma-${arch}-crb.gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-9" \
                 --forcearch="${arch}" \
-                gcc libgcc \
-                glibc glibc-devel \
-                kernel-headers \
-                elfutils-libelf elfutils-libelf-devel \
-                libpcap libpcap-devel \
-                zlib zlib-devel; \
+                ${packages}; \
             for rpm in "${tmpdir}"/*.rpm; do \
                 rpm2cpio "${rpm}" | cpio -idm -D "${sysroot}"; \
             done; \
@@ -110,6 +111,18 @@ RUN set -eux; \
                     ln -s "usr/${dir}" "${sysroot}/${dir}"; \
                 fi; \
             done; \
+            # s390x's libgcc package ships libgcc_s.so as an absolute symlink to
+            # /lib64/libgcc_s.so.1, which ld.lld follows to the host fs (--sysroot
+            # is not applied to symlinks). Replace it with a linker script (what
+            # aarch64/ppc64le ship), since ld.lld does apply --sysroot to absolute
+            # paths inside linker scripts.
+            if [ "${arch}" = "s390x" ]; then \
+                for libgcc_s in "${sysroot}"/usr/lib/gcc/s390x-redhat-linux/*/libgcc_s.so; do \
+                    [ -L "${libgcc_s}" ] || continue; \
+                    rm "${libgcc_s}"; \
+                    printf 'OUTPUT_FORMAT(elf64-s390)\nGROUP ( /lib64/libgcc_s.so.1 libgcc.a )\n' > "${libgcc_s}"; \
+                done; \
+            fi; \
         done; \
     fi
 

--- a/images/calico-go-build/versions.yaml
+++ b/images/calico-go-build/versions.yaml
@@ -9,4 +9,4 @@ golang:
 kubernetes:
   version: 1.36.1
 llvm:
-  version: 20.1.8
+  version: 21.1.8


### PR DESCRIPTION
Pick https://github.com/projectcalico/toolchain/pull/837 and https://github.com/projectcalico/toolchain/pull/841 into the go1.26 release branch.