### PR TITLE
feat(go-build): add OTel Collector Builder to toolchain image

### DIFF
--- a/images/calico-go-build/Dockerfile
+++ b/images/calico-go-build/Dockerfile
@@ -265,6 +265,7 @@ RUN set -eux; \
     go install github.com/jstemmer/go-junit-report@v1.0.0 && \
     go install github.com/onsi/ginkgo/v2/ginkgo@${GINKGO_VERSION} && \
     go install github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad && \
+    go install go.opentelemetry.io/collector/cmd/builder@v0.153.0 && \
     go install golang.org/x/tools/cmd/goimports@v0.43.0 && \
     go install golang.org/x/tools/cmd/stringer@v0.43.0 && \
     go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.1 && \


### PR DESCRIPTION
## Summary
- Cherry-pick of #866 to go1.26 branch
- Add `go.opentelemetry.io/collector/cmd/builder@v0.153.0` (OCB) to the shared `calico/go-build` toolchain image

## Test plan
- [ ] Verify go-build image builds successfully with OCB included
- [ ] Verify `builder` binary is available in PATH inside the built image

🤖 Generated with [Claude Code](https://claude.com/claude-code)