### PR TITLE
[go1.25-k8s1.34] Auto-update Go/Kubernetes versions

### DIFF
--- a/images/calico-go-build/versions.yaml
+++ b/images/calico-go-build/versions.yaml
@@ -7,6 +7,6 @@ golang:
       ppc64le: 64adb4ddefef4f0a6f11af550547f39bf510350da69ab308438a21eacfde97ad
       s390x: 09875de1d6cb3237437112271b9df3a96bac9fcd10cbf9bc777c00e67f4e3e3d
 kubernetes:
-  version: 1.34.9
+  version: 1.34.10
 llvm:
   version: 18.1.8


### PR DESCRIPTION
Automated version update for `go1.25-k8s1.34`:

Kubernetes: 1.34.9 -> 1.34.10